### PR TITLE
fix(scaffold): nil-guard ruleset slices and upsert labels

### DIFF
--- a/internal/gh/ratelimit.go
+++ b/internal/gh/ratelimit.go
@@ -62,6 +62,13 @@ func BuildBranchRuleset(name string, include, exclude, rules []string) Ruleset {
 		name = "branch-protection"
 	}
 
+	if include == nil {
+		include = []string{}
+	}
+	if exclude == nil {
+		exclude = []string{}
+	}
+
 	ruleSpecs := make([]RuleSpec, 0, len(rules))
 	for _, r := range rules {
 		ruleSpecs = append(ruleSpecs, RuleSpec{Type: r})
@@ -92,6 +99,13 @@ func BuildBranchRuleset(name string, include, exclude, rules []string) Ruleset {
 func BuildTagRuleset(name string, include, exclude, rules []string) Ruleset {
 	if name == "" {
 		name = "tag-protection"
+	}
+
+	if include == nil {
+		include = []string{}
+	}
+	if exclude == nil {
+		exclude = []string{}
 	}
 
 	ruleSpecs := make([]RuleSpec, 0, len(rules))

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -143,50 +143,47 @@ func (g *githubClient) ListRulesets(ctx context.Context, repo string) ([]Ruleset
 	return rulesets, nil
 }
 
-// SyncLabels idempotently syncs labels (PATCH existing, POST missing)
+// SyncLabels idempotently syncs labels using an upsert pattern.
+// It tries PATCH first for every label; if the label does not exist (404), it falls back to POST.
+// This avoids 422 errors on fresh repos where GitHub creates default labels asynchronously.
 func (g *githubClient) SyncLabels(ctx context.Context, repo string, labels []Label) error {
-	// List existing labels for idempotent sync
-	existing, err := g.ListLabels(ctx, repo)
-	if err != nil {
-		return appErrors.WrapWithContext(err, "list labels for sync")
-	}
-
-	existingMap := make(map[string]bool, len(existing))
-	for _, l := range existing {
-		existingMap[strings.ToLower(l.Name)] = true
-	}
-
 	for _, label := range labels {
 		jsonData, marshalErr := jsonutil.MarshalJSON(label)
 		if marshalErr != nil {
 			return appErrors.WrapWithContext(marshalErr, "marshal label")
 		}
 
-		if existingMap[strings.ToLower(label.Name)] {
-			// Update existing label
-			encodedName := strings.ReplaceAll(label.Name, " ", "%20")
-			syncErr := rateLimitedDo(ctx, defaultAPIDelay, func() error {
-				_, runErr := g.runner.RunWithInput(ctx, jsonData, "gh", "api",
-					fmt.Sprintf("repos/%s/labels/%s", repo, encodedName),
-					"--method", "PATCH", "--input", "-")
-				return runErr
-			})
-			if syncErr != nil {
-				if g.logger != nil {
-					g.logger.WithError(syncErr).Warnf("Failed to update label %q", label.Name)
-				}
+		encodedName := strings.ReplaceAll(label.Name, " ", "%20")
+
+		// Try PATCH first; treat 404 as a signal to POST instead of retrying
+		notFound := false
+		patchErr := rateLimitedDo(ctx, defaultAPIDelay, func() error {
+			_, runErr := g.runner.RunWithInput(ctx, jsonData, "gh", "api",
+				fmt.Sprintf("repos/%s/labels/%s", repo, encodedName),
+				"--method", "PATCH", "--input", "-")
+			if isNotFoundError(runErr) {
+				notFound = true
+				return nil // stop retrying; fall back to POST below
 			}
-		} else {
-			// Create new label
-			syncErr := rateLimitedDo(ctx, defaultAPIDelay, func() error {
+			return runErr
+		})
+		if patchErr != nil {
+			if g.logger != nil {
+				g.logger.WithError(patchErr).Warnf("Failed to update label %q", label.Name)
+			}
+			continue
+		}
+
+		if notFound {
+			postErr := rateLimitedDo(ctx, defaultAPIDelay, func() error {
 				_, runErr := g.runner.RunWithInput(ctx, jsonData, "gh", "api",
 					fmt.Sprintf("repos/%s/labels", repo),
 					"--method", "POST", "--input", "-")
 				return runErr
 			})
-			if syncErr != nil {
+			if postErr != nil {
 				if g.logger != nil {
-					g.logger.WithError(syncErr).Warnf("Failed to create label %q", label.Name)
+					g.logger.WithError(postErr).Warnf("Failed to create label %q", label.Name)
 				}
 			}
 		}

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -92,14 +92,14 @@ func TestBuildBranchRuleset(t *testing.T) {
 		assert.NotNil(t, rs.Rules, "rules should be an empty slice, not nil")
 	})
 
-	t.Run("nil include and exclude", func(t *testing.T) {
+	t.Run("nil include and exclude become empty slices", func(t *testing.T) {
 		t.Parallel()
 
 		rs := BuildBranchRuleset("nil-conditions", nil, nil, []string{"deletion"})
 
 		require.NotNil(t, rs.Conditions)
-		assert.Nil(t, rs.Conditions.RefName.Include)
-		assert.Nil(t, rs.Conditions.RefName.Exclude)
+		assert.Equal(t, []string{}, rs.Conditions.RefName.Include)
+		assert.Equal(t, []string{}, rs.Conditions.RefName.Exclude)
 	})
 
 	t.Run("many rules", func(t *testing.T) {
@@ -183,14 +183,14 @@ func TestBuildTagRuleset(t *testing.T) {
 		assert.NotNil(t, rs.Rules, "rules should be an empty slice, not nil")
 	})
 
-	t.Run("nil include and exclude", func(t *testing.T) {
+	t.Run("nil include and exclude become empty slices", func(t *testing.T) {
 		t.Parallel()
 
 		rs := BuildTagRuleset("nil-conditions", nil, nil, []string{"update"})
 
 		require.NotNil(t, rs.Conditions)
-		assert.Nil(t, rs.Conditions.RefName.Include)
-		assert.Nil(t, rs.Conditions.RefName.Exclude)
+		assert.Equal(t, []string{}, rs.Conditions.RefName.Include)
+		assert.Equal(t, []string{}, rs.Conditions.RefName.Exclude)
 	})
 
 	t.Run("many rules", func(t *testing.T) {
@@ -233,6 +233,38 @@ func TestBuildBranchRuleset_DefaultName_VsTagRuleset_DefaultName(t *testing.T) {
 
 	assert.Equal(t, "branch-protection", branch.Name)
 	assert.Equal(t, "tag-protection", tag.Name)
+}
+
+func TestBuildRuleset_NilIncludeExclude_SerializeToEmptyArrays(t *testing.T) {
+	t.Parallel()
+
+	t.Run("branch ruleset nil slices produce [] not null in JSON", func(t *testing.T) {
+		t.Parallel()
+
+		rs := BuildBranchRuleset("test", nil, nil, nil)
+		data, err := json.Marshal(rs.Conditions)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.Contains(t, jsonStr, `"include":[]`, "include should serialize as empty array")
+		assert.Contains(t, jsonStr, `"exclude":[]`, "exclude should serialize as empty array")
+		assert.NotContains(t, jsonStr, `"include":null`)
+		assert.NotContains(t, jsonStr, `"exclude":null`)
+	})
+
+	t.Run("tag ruleset nil slices produce [] not null in JSON", func(t *testing.T) {
+		t.Parallel()
+
+		rs := BuildTagRuleset("test", nil, nil, nil)
+		data, err := json.Marshal(rs.Conditions)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.Contains(t, jsonStr, `"include":[]`, "include should serialize as empty array")
+		assert.Contains(t, jsonStr, `"exclude":[]`, "exclude should serialize as empty array")
+		assert.NotContains(t, jsonStr, `"include":null`)
+		assert.NotContains(t, jsonStr, `"exclude":null`)
+	})
 }
 
 // Tests for githubClient settings methods
@@ -578,8 +610,9 @@ func TestSyncLabels_NewLabel(t *testing.T) {
 	mockRunner := new(MockCommandRunner)
 	client := NewClientWithRunner(mockRunner, logrus.New())
 
-	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/repo/labels", "--paginate"}).
-		Return([]byte("[]"), nil)
+	// PATCH returns 404 (label doesn't exist yet) → fall back to POST
+	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{"api", "repos/owner/repo/labels/bug", "--method", "PATCH", "--input", "-"}).
+		Return(nil, &CommandError{Stderr: "404 Not Found"})
 	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{"api", "repos/owner/repo/labels", "--method", "POST", "--input", "-"}).
 		Return([]byte("{}"), nil)
 
@@ -594,33 +627,28 @@ func TestSyncLabels_ExistingLabel(t *testing.T) {
 	mockRunner := new(MockCommandRunner)
 	client := NewClientWithRunner(mockRunner, logrus.New())
 
-	existing := []Label{{Name: "bug", Color: "old-color"}}
-	existingJSON, err := json.Marshal(existing)
-	require.NoError(t, err)
-
-	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/repo/labels", "--paginate"}).
-		Return(existingJSON, nil)
+	// PATCH succeeds directly — no ListLabels needed with upsert pattern
 	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{"api", "repos/owner/repo/labels/bug", "--method", "PATCH", "--input", "-"}).
 		Return([]byte("{}"), nil)
 
 	labels := []Label{{Name: "bug", Color: "d73a4a"}}
-	err = client.SyncLabels(ctx, "owner/repo", labels)
+	err := client.SyncLabels(ctx, "owner/repo", labels)
 	require.NoError(t, err)
 	mockRunner.AssertExpectations(t)
 }
 
-func TestSyncLabels_ListError(t *testing.T) {
+func TestSyncLabels_PatchNonFoundError_LogsAndContinues(t *testing.T) {
 	ctx := context.Background()
 	mockRunner := new(MockCommandRunner)
 	client := NewClientWithRunner(mockRunner, logrus.New())
 
-	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/repo/labels", "--paginate"}).
+	// PATCH fails with a non-404 error; should log warning and return nil (not propagate error)
+	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{"api", "repos/owner/repo/labels/bug", "--method", "PATCH", "--input", "-"}).
 		Return(nil, errTestLabelsFetchError)
 
 	labels := []Label{{Name: "bug", Color: "d73a4a"}}
 	err := client.SyncLabels(ctx, "owner/repo", labels)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "list labels for sync")
+	require.NoError(t, err) // errors are logged, not returned
 	mockRunner.AssertExpectations(t)
 }
 
@@ -629,19 +657,16 @@ func TestSyncLabels_MixedNew_And_Existing(t *testing.T) {
 	mockRunner := new(MockCommandRunner)
 	client := NewClientWithRunner(mockRunner, logrus.New())
 
-	existing := []Label{{Name: "bug", Color: "d73a4a"}}
-	existingJSON, err := json.Marshal(existing)
-	require.NoError(t, err)
-
-	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/repo/labels", "--paginate"}).
-		Return(existingJSON, nil)
+	// "bug" exists: PATCH succeeds; "feature" is new: PATCH returns 404, POST creates it
 	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{"api", "repos/owner/repo/labels/bug", "--method", "PATCH", "--input", "-"}).
 		Return([]byte("{}"), nil)
+	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{"api", "repos/owner/repo/labels/feature", "--method", "PATCH", "--input", "-"}).
+		Return(nil, &CommandError{Stderr: "404 Not Found"})
 	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{"api", "repos/owner/repo/labels", "--method", "POST", "--input", "-"}).
 		Return([]byte("{}"), nil)
 
 	labels := []Label{{Name: "bug", Color: "d73a4a"}, {Name: "feature", Color: "a2eeef"}}
-	err = client.SyncLabels(ctx, "owner/repo", labels)
+	err := client.SyncLabels(ctx, "owner/repo", labels)
 	require.NoError(t, err)
 	mockRunner.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in the scaffold command:

### Bug 1: Ruleset creation fails with null exclude array (#139)

`BuildBranchRuleset` and `BuildTagRuleset` passed nil `include`/`exclude` slices into `RefNameCondition`. `json.Marshal` serialized nil slices as `null`, but GitHub API requires `[]`.

**Fix:** Nil-guard both slices in both builder functions before struct assignment.

### Bug 2: SyncLabels 422 on fresh repos (#140)

`SyncLabels` listed existing labels then branched POST vs PATCH. On freshly created repos, GitHub creates default labels asynchronously — `ListLabels` could miss them, causing POST to fail with 422.

**Fix:** Replace list-then-branch with PATCH-first upsert pattern. For each label: try PATCH first. If 404, fall back to POST. Fully idempotent regardless of race conditions.

### Tests
- Updated existing ruleset tests to assert `[]string{}` instead of nil
- Added `TestBuildRuleset_NilIncludeExclude_SerializeToEmptyArrays` with JSON serialization verification
- Updated all SyncLabels tests to match upsert pattern (PATCH→404→POST)
- Added `TestSyncLabels_PatchNonFoundError_LogsAndContinues`

### Validation
- `go test ./internal/gh/... -race -count=1` ✅
- `go vet ./...` ✅
- `golangci-lint run ./internal/gh/... ./internal/cli/...` ✅

Closes #139
Closes #140