### PR TITLE
feat(scaffold): create initial README on master and clone locally

### DIFF
--- a/internal/cli/scaffold_service.go
+++ b/internal/cli/scaffold_service.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mrz1836/go-broadcast/internal/config"
@@ -44,10 +45,14 @@ func RunScaffold(ctx context.Context, ghClient gh.Client, opts ScaffoldOptions) 
 		if len(opts.Topics) > 0 {
 			output.Info(fmt.Sprintf("    3. Set topics: %s", strings.Join(opts.Topics, ", ")))
 		}
-		output.Info(fmt.Sprintf("    4. Sync %d labels", len(opts.Preset.Labels)))
-		output.Info(fmt.Sprintf("    5. Create %d rulesets", len(opts.Preset.Rulesets)))
+		if !opts.NoFiles {
+			output.Info("    4. Create initial README.md")
+		}
+		output.Info("    5. Rename branch main → master")
+		output.Info(fmt.Sprintf("    6. Sync %d labels", len(opts.Preset.Labels)))
+		output.Info(fmt.Sprintf("    7. Create %d rulesets", len(opts.Preset.Rulesets)))
 		if !opts.NoClone {
-			output.Info("    6. Clone repository locally")
+			output.Info("    8. Clone repository locally")
 		}
 		return &ScaffoldResult{RepoFullName: repoFullName}, nil
 	}
@@ -84,7 +89,26 @@ func RunScaffold(ctx context.Context, ghClient gh.Client, opts ScaffoldOptions) 
 		}
 	}
 
-	// Step 4: Sync labels
+	// Step 4: Create initial README.md on main branch
+	if !opts.NoFiles {
+		output.Info("Creating initial README.md...")
+		readmeContent := []byte(fmt.Sprintf("# %s\n\n%s\n", opts.Name, opts.Description))
+		if err = ghClient.CreateFileCommit(ctx, repoFullName, "README.md", "Initial commit", readmeContent, "main"); err != nil {
+			output.Warn(fmt.Sprintf("Failed to create README.md: %v (continuing...)", err))
+		} else {
+			output.Success("README.md created")
+		}
+	}
+
+	// Step 5: Rename default branch main → master
+	output.Info("Renaming default branch to master...")
+	if err = ghClient.RenameBranch(ctx, repoFullName, "main", "master"); err != nil {
+		output.Warn(fmt.Sprintf("Failed to rename branch: %v (continuing...)", err))
+	} else {
+		output.Success("Default branch renamed to master")
+	}
+
+	// Step 6: Sync labels
 	if len(opts.Preset.Labels) > 0 {
 		output.Info("Syncing labels...")
 		labels := presetLabelsToGH(opts.Preset.Labels)
@@ -95,7 +119,7 @@ func RunScaffold(ctx context.Context, ghClient gh.Client, opts ScaffoldOptions) 
 		}
 	}
 
-	// Step 5: Create rulesets
+	// Step 7: Create rulesets
 	for _, rc := range opts.Preset.Rulesets {
 		output.Info(fmt.Sprintf("Creating ruleset: %s...", rc.Name))
 		ruleset := configRulesetToGH(&rc)
@@ -106,10 +130,29 @@ func RunScaffold(ctx context.Context, ghClient gh.Client, opts ScaffoldOptions) 
 		}
 	}
 
-	return &ScaffoldResult{
+	result := &ScaffoldResult{
 		RepoFullName: repoFullName,
 		Created:      true,
-	}, nil
+	}
+
+	// Step 8: Clone repository locally
+	if !opts.NoClone {
+		homeDir, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			output.Warn(fmt.Sprintf("Failed to get home directory for clone: %v (skipping clone)", homeErr))
+		} else {
+			clonePath := homeDir + "/projects/" + opts.Name
+			output.Info(fmt.Sprintf("Cloning repository to %s...", clonePath))
+			if cloneErr := ghClient.CloneRepository(ctx, repoFullName, clonePath); cloneErr != nil {
+				output.Warn(fmt.Sprintf("Failed to clone repository: %v (continuing...)", cloneErr))
+			} else {
+				result.ClonePath = clonePath
+				output.Success(fmt.Sprintf("Repository cloned to %s", clonePath))
+			}
+		}
+	}
+
+	return result, nil
 }
 
 // presetToRepoSettings converts a config preset to gh.RepoSettings

--- a/internal/cli/scaffold_test.go
+++ b/internal/cli/scaffold_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,10 @@ func TestRunScaffold_CreateSuccess(t *testing.T) {
 	ctx := context.Background()
 	preset := config.DefaultPreset()
 
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	clonePath := homeDir + "/projects/my-repo"
+
 	mockClient := new(gh.MockClient)
 	mockClient.On("CreateRepository", ctx, gh.CreateRepoOptions{
 		Name:        "acme/my-repo",
@@ -43,10 +48,14 @@ func TestRunScaffold_CreateSuccess(t *testing.T) {
 	}).Return(&gh.Repository{Name: "my-repo"}, nil)
 	mockClient.On("UpdateRepoSettings", ctx, "acme/my-repo", presetToRepoSettings(&preset)).Return(nil)
 	mockClient.On("SetTopics", ctx, "acme/my-repo", []string{"go"}).Return(nil)
+	mockClient.On("CreateFileCommit", ctx, "acme/my-repo", "README.md", "Initial commit",
+		[]byte("# my-repo\n\nA test repo\n"), "main").Return(nil)
+	mockClient.On("RenameBranch", ctx, "acme/my-repo", "main", "master").Return(nil)
 	mockClient.On("SyncLabels", ctx, "acme/my-repo", presetLabelsToGH(preset.Labels)).Return(nil)
 	for _, rc := range preset.Rulesets {
 		mockClient.On("CreateOrUpdateRuleset", ctx, "acme/my-repo", configRulesetToGH(&rc)).Return(nil)
 	}
+	mockClient.On("CloneRepository", ctx, "acme/my-repo", clonePath).Return(nil)
 
 	opts := ScaffoldOptions{
 		Name:        "my-repo",
@@ -61,6 +70,7 @@ func TestRunScaffold_CreateSuccess(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.Created)
 	assert.Equal(t, "acme/my-repo", result.RepoFullName)
+	assert.Equal(t, clonePath, result.ClonePath)
 	mockClient.AssertExpectations(t)
 }
 
@@ -86,6 +96,79 @@ func TestRunScaffold_CreateFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to create repository")
+}
+
+func TestRunScaffold_NoClone(t *testing.T) {
+	ctx := context.Background()
+	preset := config.DefaultPreset()
+
+	mockClient := new(gh.MockClient)
+	mockClient.On("CreateRepository", ctx, gh.CreateRepoOptions{
+		Name:        "acme/my-repo",
+		Description: "test",
+		Private:     true,
+	}).Return(&gh.Repository{Name: "my-repo"}, nil)
+	mockClient.On("UpdateRepoSettings", ctx, "acme/my-repo", presetToRepoSettings(&preset)).Return(nil)
+	mockClient.On("CreateFileCommit", ctx, "acme/my-repo", "README.md", "Initial commit",
+		[]byte("# my-repo\n\ntest\n"), "main").Return(nil)
+	mockClient.On("RenameBranch", ctx, "acme/my-repo", "main", "master").Return(nil)
+	mockClient.On("SyncLabels", ctx, "acme/my-repo", presetLabelsToGH(preset.Labels)).Return(nil)
+	for _, rc := range preset.Rulesets {
+		mockClient.On("CreateOrUpdateRuleset", ctx, "acme/my-repo", configRulesetToGH(&rc)).Return(nil)
+	}
+
+	opts := ScaffoldOptions{
+		Name:        "my-repo",
+		Description: "test",
+		Owner:       "acme",
+		Preset:      &preset,
+		NoClone:     true,
+	}
+
+	result, err := RunScaffold(ctx, mockClient, opts)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Created)
+	assert.Empty(t, result.ClonePath)
+	mockClient.AssertExpectations(t)
+}
+
+func TestRunScaffold_NoFiles(t *testing.T) {
+	ctx := context.Background()
+	preset := config.DefaultPreset()
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	clonePath := homeDir + "/projects/my-repo"
+
+	mockClient := new(gh.MockClient)
+	mockClient.On("CreateRepository", ctx, gh.CreateRepoOptions{
+		Name:        "acme/my-repo",
+		Description: "test",
+		Private:     true,
+	}).Return(&gh.Repository{Name: "my-repo"}, nil)
+	mockClient.On("UpdateRepoSettings", ctx, "acme/my-repo", presetToRepoSettings(&preset)).Return(nil)
+	mockClient.On("RenameBranch", ctx, "acme/my-repo", "main", "master").Return(nil)
+	mockClient.On("SyncLabels", ctx, "acme/my-repo", presetLabelsToGH(preset.Labels)).Return(nil)
+	for _, rc := range preset.Rulesets {
+		mockClient.On("CreateOrUpdateRuleset", ctx, "acme/my-repo", configRulesetToGH(&rc)).Return(nil)
+	}
+	mockClient.On("CloneRepository", ctx, "acme/my-repo", clonePath).Return(nil)
+
+	opts := ScaffoldOptions{
+		Name:        "my-repo",
+		Description: "test",
+		Owner:       "acme",
+		Preset:      &preset,
+		NoFiles:     true,
+	}
+
+	result, err := RunScaffold(ctx, mockClient, opts)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Created)
+	assert.Equal(t, clonePath, result.ClonePath)
+	mockClient.AssertExpectations(t)
 }
 
 func TestPresetToRepoSettings(t *testing.T) {

--- a/internal/cli/settings_integration_test.go
+++ b/internal/cli/settings_integration_test.go
@@ -29,6 +29,9 @@ func TestSettingsIntegration_ScaffoldThenAudit(t *testing.T) {
 		Private:     true,
 	}).Return(&gh.Repository{Name: "integration-test"}, nil)
 	mockClient.On("UpdateRepoSettings", ctx, "acme/integration-test", presetToRepoSettings(&preset)).Return(nil)
+	mockClient.On("CreateFileCommit", ctx, "acme/integration-test", "README.md", "Initial commit",
+		[]byte("# integration-test\n\nIntegration test repo\n"), "main").Return(nil)
+	mockClient.On("RenameBranch", ctx, "acme/integration-test", "main", "master").Return(nil)
 	mockClient.On("SyncLabels", ctx, "acme/integration-test", presetLabelsToGH(preset.Labels)).Return(nil)
 	for _, rc := range preset.Rulesets {
 		mockClient.On("CreateOrUpdateRuleset", ctx, "acme/integration-test", configRulesetToGH(&rc)).Return(nil)

--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -142,4 +142,13 @@ type Client interface {
 
 	// SetTopics replaces all topics for a repository
 	SetTopics(ctx context.Context, repo string, topics []string) error
+
+	// CloneRepository clones a GitHub repository to the specified local path
+	CloneRepository(ctx context.Context, repo string, destPath string) error
+
+	// CreateFileCommit creates or updates a file in a repository via the Contents API
+	CreateFileCommit(ctx context.Context, repo, path, message string, content []byte, branch string) error
+
+	// RenameBranch renames a branch in a repository
+	RenameBranch(ctx context.Context, repo, oldName, newName string) error
 }

--- a/internal/gh/mock.go
+++ b/internal/gh/mock.go
@@ -272,3 +272,21 @@ func (m *MockClient) SetTopics(ctx context.Context, repo string, topics []string
 	args := m.Called(ctx, repo, topics)
 	return args.Error(0)
 }
+
+// CloneRepository mock implementation
+func (m *MockClient) CloneRepository(ctx context.Context, repo string, destPath string) error {
+	args := m.Called(ctx, repo, destPath)
+	return args.Error(0)
+}
+
+// CreateFileCommit mock implementation
+func (m *MockClient) CreateFileCommit(ctx context.Context, repo, path, message string, content []byte, branch string) error {
+	args := m.Called(ctx, repo, path, message, content, branch)
+	return args.Error(0)
+}
+
+// RenameBranch mock implementation
+func (m *MockClient) RenameBranch(ctx context.Context, repo, oldName, newName string) error {
+	args := m.Called(ctx, repo, oldName, newName)
+	return args.Error(0)
+}

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -2,6 +2,7 @@ package gh
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -214,6 +215,50 @@ func (g *githubClient) ListLabels(ctx context.Context, repo string) ([]Label, er
 	}
 
 	return labels, nil
+}
+
+// CloneRepository clones a GitHub repository to the specified local path
+func (g *githubClient) CloneRepository(ctx context.Context, repo string, destPath string) error {
+	return rateLimitedDo(ctx, defaultAPIDelay, func() error {
+		_, runErr := g.runner.Run(ctx, "gh", "repo", "clone", repo, destPath)
+		return runErr
+	})
+}
+
+// CreateFileCommit creates or updates a file in a repository via the Contents API
+func (g *githubClient) CreateFileCommit(ctx context.Context, repo, path, message string, content []byte, branch string) error {
+	payload := map[string]string{
+		"message": message,
+		"content": base64.StdEncoding.EncodeToString(content),
+		"branch":  branch,
+	}
+	jsonData, err := jsonutil.MarshalJSON(payload)
+	if err != nil {
+		return appErrors.WrapWithContext(err, "marshal file commit")
+	}
+
+	return rateLimitedDo(ctx, defaultAPIDelay, func() error {
+		_, runErr := g.runner.RunWithInput(ctx, jsonData, "gh", "api",
+			fmt.Sprintf("repos/%s/contents/%s", repo, path),
+			"--method", "PUT", "--input", "-")
+		return runErr
+	})
+}
+
+// RenameBranch renames a branch in a repository
+func (g *githubClient) RenameBranch(ctx context.Context, repo, oldName, newName string) error {
+	payload := map[string]string{"new_name": newName}
+	jsonData, err := jsonutil.MarshalJSON(payload)
+	if err != nil {
+		return appErrors.WrapWithContext(err, "marshal rename branch")
+	}
+
+	return rateLimitedDo(ctx, defaultAPIDelay, func() error {
+		_, runErr := g.runner.RunWithInput(ctx, jsonData, "gh", "api",
+			fmt.Sprintf("repos/%s/branches/%s/rename", repo, oldName),
+			"--method", "POST", "--input", "-")
+		return runErr
+	})
 }
 
 // SetTopics replaces all topics for a repository

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -672,3 +672,92 @@ func TestSetTopics_RunnerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "topics error")
 	mockRunner.AssertExpectations(t)
 }
+
+func TestCloneRepository_Success(t *testing.T) {
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	mockRunner.On("Run", ctx, "gh", []string{"repo", "clone", "owner/my-repo", "/home/user/projects/my-repo"}).
+		Return([]byte{}, nil)
+
+	err := client.CloneRepository(ctx, "owner/my-repo", "/home/user/projects/my-repo")
+	require.NoError(t, err)
+	mockRunner.AssertExpectations(t)
+}
+
+func TestCloneRepository_RunnerError(t *testing.T) {
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	mockRunner.On("Run", ctx, "gh", []string{"repo", "clone", "owner/my-repo", "/home/user/projects/my-repo"}).
+		Return(nil, errTestCLIError)
+
+	err := client.CloneRepository(ctx, "owner/my-repo", "/home/user/projects/my-repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cli error")
+	mockRunner.AssertExpectations(t)
+}
+
+func TestCreateFileCommit_Success(t *testing.T) {
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{
+		"api", "repos/owner/repo/contents/README.md",
+		"--method", "PUT", "--input", "-",
+	}).Return([]byte("{}"), nil)
+
+	err := client.CreateFileCommit(ctx, "owner/repo", "README.md", "Initial commit", []byte("# test\n"), "main")
+	require.NoError(t, err)
+	mockRunner.AssertExpectations(t)
+}
+
+func TestCreateFileCommit_RunnerError(t *testing.T) {
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{
+		"api", "repos/owner/repo/contents/README.md",
+		"--method", "PUT", "--input", "-",
+	}).Return(nil, errTestCLIError)
+
+	err := client.CreateFileCommit(ctx, "owner/repo", "README.md", "Initial commit", []byte("# test\n"), "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cli error")
+	mockRunner.AssertExpectations(t)
+}
+
+func TestRenameBranch_Success(t *testing.T) {
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{
+		"api", "repos/owner/repo/branches/main/rename",
+		"--method", "POST", "--input", "-",
+	}).Return([]byte("{}"), nil)
+
+	err := client.RenameBranch(ctx, "owner/repo", "main", "master")
+	require.NoError(t, err)
+	mockRunner.AssertExpectations(t)
+}
+
+func TestRenameBranch_RunnerError(t *testing.T) {
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	mockRunner.On("RunWithInput", ctx, mock.Anything, "gh", []string{
+		"api", "repos/owner/repo/branches/main/rename",
+		"--method", "POST", "--input", "-",
+	}).Return(nil, errTestCLIError)
+
+	err := client.RenameBranch(ctx, "owner/repo", "main", "master")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cli error")
+	mockRunner.AssertExpectations(t)
+}

--- a/internal/sync/directory_transform_test.go
+++ b/internal/sync/directory_transform_test.go
@@ -1067,6 +1067,18 @@ func (m *DirectoryMockGHClient) GetDependabotAlerts(_ context.Context, _ string)
 	return nil, nil
 }
 
+func (m *DirectoryMockGHClient) CloneRepository(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (m *DirectoryMockGHClient) CreateFileCommit(_ context.Context, _, _, _ string, _ []byte, _ string) error {
+	return nil
+}
+
+func (m *DirectoryMockGHClient) RenameBranch(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (m *DirectoryMockGHClient) GetCodeScanningAlerts(_ context.Context, _ string) ([]gh.CodeScanningAlert, error) {
 	return nil, nil
 }

--- a/internal/sync/repository_test.go
+++ b/internal/sync/repository_test.go
@@ -1940,6 +1940,18 @@ func (m *TestValidationMockGHClient) SetTopics(_ context.Context, _ string, _ []
 	return ErrMockNotImplemented
 }
 
+func (m *TestValidationMockGHClient) CloneRepository(_ context.Context, _, _ string) error {
+	return ErrMockNotImplemented
+}
+
+func (m *TestValidationMockGHClient) CreateFileCommit(_ context.Context, _, _, _ string, _ []byte, _ string) error {
+	return ErrMockNotImplemented
+}
+
+func (m *TestValidationMockGHClient) RenameBranch(_ context.Context, _, _, _ string) error {
+	return ErrMockNotImplemented
+}
+
 // TestRepositorySync_validateAndCleanupOrphanedBranches tests the validateAndCleanupOrphanedBranches method
 func TestRepositorySync_validateAndCleanupOrphanedBranches(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Implements the remaining scaffold gaps:

### #141: Clone step
- Added `CloneRepository` to the GH client
- Scaffold now clones to `~/projects/<repo_name>` by default
- `--no-clone` is respected
- `ScaffoldResult.ClonePath` is now populated

### #142: Initial README + master branch
- Added `CreateFileCommit` to create `README.md` via the GitHub contents API
- README content: `# <repo_name>\n\n<description>\n`
- Added `RenameBranch` to rename `main` → `master`
- `--no-files` skips README creation but branch rename still runs

## Updated scaffold flow
1. Create repository
2. Apply settings from preset
3. Set topics
4. Create initial `README.md` (unless `--no-files`)
5. Rename branch `main` → `master`
6. Sync labels
7. Create rulesets
8. Clone to `~/projects/<repo_name>` (unless `--no-clone`)

## Tests
- Added GH client tests for `CloneRepository`, `CreateFileCommit`, and `RenameBranch`
- Updated scaffold tests for clone path + no-clone/no-files behavior
- Updated integration test expectations
- Fixed test-only mocks impacted by `gh.Client` interface expansion

## Validation
- `go test ./internal/gh/... ./internal/cli/... -race -count=1` ✅
- `go vet ./...` ✅
- `golangci-lint run ./internal/gh/... ./internal/cli/...` ✅

Closes #141
Closes #142
