### PR TITLE
fix(gh): retry post-create repository lookup on 404 propagation lag

### DIFF
--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -3,12 +3,24 @@ package gh
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	appErrors "github.com/mrz1836/go-broadcast/internal/errors"
 	"github.com/mrz1836/go-broadcast/internal/jsonutil"
 )
+
+// createRepoRetryDelays controls the backoff between post-create GetRepository
+// retries. GitHub's eventual-consistency window often returns 404 on the first
+// fetch even after a successful `gh repo create`. Exposed as a var so tests can
+// override with small values.
+var createRepoRetryDelays = []time.Duration{ //nolint:gochecknoglobals // tunable retry schedule, override in tests
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+}
 
 // CreateRepository creates a new GitHub repository
 func (g *githubClient) CreateRepository(ctx context.Context, opts CreateRepoOptions) (*Repository, error) {
@@ -24,7 +36,6 @@ func (g *githubClient) CreateRepository(ctx context.Context, opts CreateRepoOpti
 		"--clone=false",
 	}
 
-	var result *Repository
 	err := rateLimitedDo(ctx, defaultAPIDelay, func() error {
 		_, runErr := g.runner.Run(ctx, "gh", args...)
 		return runErr
@@ -33,13 +44,44 @@ func (g *githubClient) CreateRepository(ctx context.Context, opts CreateRepoOpti
 		return nil, appErrors.WrapWithContext(err, "create repository")
 	}
 
-	// Fetch the created repository details
-	result, err = g.GetRepository(ctx, opts.Name)
-	if err != nil {
-		return nil, appErrors.WrapWithContext(err, "get created repository")
+	// Fetch the created repository details. GitHub may return 404 briefly after
+	// the create succeeds (propagation lag) — retry on 404 only. Other errors
+	// (5xx, network, auth) bubble up immediately.
+	maxAttempts := len(createRepoRetryDelays) + 1
+	var result *Repository
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		result, err = g.GetRepository(ctx, opts.Name)
+		if err == nil {
+			return result, nil
+		}
+
+		if !errors.Is(err, ErrRepositoryNotFound) {
+			return nil, appErrors.WrapWithContext(err, "get created repository")
+		}
+
+		if attempt >= maxAttempts {
+			break
+		}
+
+		delay := createRepoRetryDelays[attempt-1]
+		if g.logger != nil {
+			g.logger.Warnf(
+				"post-create GetRepository returned 404 for %s — propagation pending, retry %d/%d after %s",
+				opts.Name, attempt, maxAttempts, delay,
+			)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
 	}
 
-	return result, nil
+	return nil, fmt.Errorf(
+		"repository propagation timed out after %d attempts: %s: %w",
+		maxAttempts, opts.Name, err,
+	)
 }
 
 // UpdateRepoSettings updates repository settings via PATCH /repos/{owner}/{repo}

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -22,6 +25,8 @@ var (
 	errTestLabelsError         = errors.New("labels error")
 	errTestLabelsFetchError    = errors.New("labels fetch error")
 	errTestTopicsError         = errors.New("topics error")
+	errTestHTTP404NotFound     = errors.New("HTTP 404 Not Found")
+	errTestHTTP500             = errors.New("HTTP 500 Internal Server Error")
 )
 
 func TestBuildBranchRuleset(t *testing.T) {
@@ -322,6 +327,102 @@ func TestCreateRepository_GetRepositoryError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "get created repository")
+	mockRunner.AssertExpectations(t)
+}
+
+// setFastCreateRepoDelays swaps the package-level retry schedule with 1ms delays
+// for fast tests, restoring the original on cleanup.
+func setFastCreateRepoDelays(t *testing.T) {
+	t.Helper()
+	orig := createRepoRetryDelays
+	createRepoRetryDelays = []time.Duration{
+		1 * time.Millisecond,
+		1 * time.Millisecond,
+		1 * time.Millisecond,
+	}
+	t.Cleanup(func() { createRepoRetryDelays = orig })
+}
+
+func TestCreateRepository_RetriesOn404ThenSuccess(t *testing.T) {
+	setFastCreateRepoDelays(t)
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.WarnLevel)
+	client := NewClientWithRunner(mockRunner, logger)
+
+	opts := CreateRepoOptions{Name: "owner/my-repo", Description: "desc", Private: true}
+	repo := Repository{Name: "my-repo", FullName: "owner/my-repo"}
+	repoJSON, err := json.Marshal(repo)
+	require.NoError(t, err)
+
+	// create succeeds
+	mockRunner.On("Run", ctx, "gh", []string{"repo", "create", "owner/my-repo", "--description", "desc", "--private", "--clone=false"}).
+		Return([]byte{}, nil).Once()
+	// 1st GET → 404
+	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/my-repo"}).
+		Return(nil, errTestHTTP404NotFound).Once()
+	// 2nd GET → success
+	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/my-repo"}).
+		Return(repoJSON, nil).Once()
+
+	result, err := client.CreateRepository(ctx, opts)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "my-repo", result.Name)
+
+	// exactly one retry log line
+	warnCount := 0
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "propagation pending") {
+			warnCount++
+		}
+	}
+	assert.Equal(t, 1, warnCount, "expected exactly one retry warn log")
+	mockRunner.AssertExpectations(t)
+}
+
+func TestCreateRepository_RetriesExhausted(t *testing.T) {
+	setFastCreateRepoDelays(t)
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	opts := CreateRepoOptions{Name: "owner/my-repo", Description: "desc", Private: true}
+	mockRunner.On("Run", ctx, "gh", []string{"repo", "create", "owner/my-repo", "--description", "desc", "--private", "--clone=false"}).
+		Return([]byte{}, nil).Once()
+	// every GET returns 404 (4 attempts: initial + 3 backoffs)
+	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/my-repo"}).
+		Return(nil, errTestHTTP404NotFound).Times(len(createRepoRetryDelays) + 1)
+
+	result, err := client.CreateRepository(ctx, opts)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "propagation timed out")
+	assert.Contains(t, err.Error(), "owner/my-repo")
+	require.ErrorIs(t, err, ErrRepositoryNotFound, "exhaustion error should still wrap ErrRepositoryNotFound")
+	mockRunner.AssertExpectations(t)
+}
+
+func TestCreateRepository_DoesNotRetryOn5xx(t *testing.T) {
+	setFastCreateRepoDelays(t)
+	ctx := context.Background()
+	mockRunner := new(MockCommandRunner)
+	client := NewClientWithRunner(mockRunner, logrus.New())
+
+	opts := CreateRepoOptions{Name: "owner/my-repo", Description: "desc", Private: false}
+	mockRunner.On("Run", ctx, "gh", []string{"repo", "create", "owner/my-repo", "--description", "desc", "--public", "--clone=false"}).
+		Return([]byte{}, nil).Once()
+	// single GET → 500, no retry
+	mockRunner.On("Run", ctx, "gh", []string{"api", "repos/owner/my-repo"}).
+		Return(nil, errTestHTTP500).Once()
+
+	result, err := client.CreateRepository(ctx, opts)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "get created repository")
+	assert.NotContains(t, err.Error(), "propagation timed out")
 	mockRunner.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary
- retry the post-create repository lookup when GitHub briefly returns 404 during propagation
- log each retry attempt so propagation lag is observable
- return a propagation-timeout error after retries exhaust

## Testing
- go test ./internal/gh/... -race -count=1