### PR TITLE
feat: preset source discoverability and idempotent seeding

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -1,0 +1,146 @@
+# Presets — Discoverability and Seeding
+
+This document covers how `go-broadcast` discovers settings presets, what is
+shipped out of the box, and how to layer your own preset definitions on top.
+
+For the complete preset schema and the `scaffold` / `settings apply` /
+`settings audit` workflows, see [`settings.md`](./settings.md).
+
+## Resolution Chain
+
+When any command needs a preset (for example `--preset go-lib`), the
+following sources are consulted in order:
+
+1. **Database** (`SettingsPreset` rows in the local SQLite DB)
+2. **Config file** (entries under `settings_presets:` in `sync.yaml`, or
+   whichever path is supplied via `--config`)
+3. **Bundled defaults** compiled into the binary (`mvp`, `go-lib`)
+
+The first source to yield a match wins. If no source has the requested id,
+the command exits with:
+
+```
+unknown preset: <id> (run 'go-broadcast presets list' to see available)
+```
+
+There is **no silent fallback** for unknown ids — typos surface immediately
+instead of being papered over with a placeholder preset.
+
+### Reserved `default` id
+
+The literal id `default` is reserved and always resolves to the hardcoded
+fallback returned by `config.DefaultPreset()`. Use it to opt out of the
+discovery chain when you explicitly want the built-in defaults regardless of
+DB or config-file overrides.
+
+```bash
+go-broadcast scaffold owner/example "Demo" --preset default
+```
+
+## Bundled Defaults
+
+Two generic presets ship with the binary:
+
+| ID       | Description                                                      |
+|----------|------------------------------------------------------------------|
+| `mvp`    | Minimal preset for any new repository (issues + squash merge)    |
+| `go-lib` | Standard Go library preset (labels, branch and tag protection)   |
+
+Both are intentionally generic so any fork of the project gets sensible
+out-of-the-box behavior. They are also auto-seeded into the local
+database the first time a preset-resolving command runs against an empty
+preset table:
+
+```
+INFO  auto-seeded bundled preset(s) into empty DB count=2
+```
+
+After auto-seeding, the bundled defaults are stored as ordinary DB rows and
+can be edited, overridden, or deleted like any other preset.
+
+## Listing Presets
+
+```bash
+# Plain id list
+go-broadcast presets list
+
+# Annotate each entry with its source
+go-broadcast presets list --show-source
+
+# Machine-readable
+go-broadcast presets list --json
+```
+
+The `--show-source` annotations are:
+
+- `db` — stored in the local database
+- `config-file:<path>` — defined in the supplied config file
+- `bundled-default` — compiled into the binary
+
+When the same id appears in multiple sources, every occurrence is listed so
+the resolution chain is fully visible.
+
+## Seeding Custom Presets
+
+Use `presets seed` to keep the database in sync with a directory of preset
+definitions:
+
+```bash
+# Re-seed the bundled defaults (idempotent — existing rows are kept)
+go-broadcast presets seed
+
+# Layer your own presets on top
+go-broadcast presets seed --from /path/to/preset-yamls/
+```
+
+`--from <dir>` walks the directory and parses every `*.yaml`, `*.yml`, and
+`*.json` file as a single preset. Each file produces one row, keyed by the
+`id` field. When a file's id matches an existing row (including a bundled
+default), the row is overridden and the change is logged at INFO. Re-running
+the command on the same directory is safe — the result converges to the
+current contents of the directory.
+
+### Example preset YAML
+
+```yaml
+id: my-team
+name: My Team Preset
+description: Team-wide defaults for new repositories
+has_issues: true
+has_wiki: false
+allow_squash_merge: true
+allow_merge_commit: false
+delete_branch_on_merge: true
+squash_merge_commit_title: PR_TITLE
+squash_merge_commit_message: COMMIT_MESSAGES
+labels:
+  - name: bug
+    color: d73a4a
+    description: Something isn't working
+  - name: chore
+    color: cccccc
+    description: Maintenance work
+rulesets:
+  - name: branch-protection
+    target: branch
+    enforcement: active
+    include:
+      - "~DEFAULT_BRANCH"
+    rules:
+      - deletion
+      - pull_request
+```
+
+Place the file in your seed directory and run:
+
+```bash
+go-broadcast presets seed --from /path/to/preset-yamls/
+go-broadcast presets list --show-source   # confirm the new row shows source=db
+```
+
+## Where to Look Next
+
+- `go-broadcast db status` — prints DB table counts and points at
+  `presets list` for the cross-source inventory
+- [`settings.md`](./settings.md) — full preset schema, scaffold/apply/audit
+  workflows, and `db preset` CRUD commands

--- a/internal/cli/db_status.go
+++ b/internal/cli/db_status.go
@@ -175,6 +175,10 @@ func printStatus(status DBStatus) error {
 		output.Info(fmt.Sprintf("  %-30s %d", table+":", count))
 	}
 
+	if _, hasPresets := status.TableCounts["settings_presets"]; hasPresets {
+		output.Info("  → run 'go-broadcast presets list' for full inventory across sources")
+	}
+
 	return nil
 }
 

--- a/internal/cli/db_target_crud.go
+++ b/internal/cli/db_target_crud.go
@@ -605,7 +605,11 @@ func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branc
 			}
 		}
 
-		preset := resolvePreset(ctx, presetID)
+		preset, presetErr := resolvePreset(ctx, presetID)
+		if presetErr != nil {
+			return printErrorResponse("target", "cloned", presetErr.Error(),
+				"run 'go-broadcast presets list' to see available presets", jsonOutput)
+		}
 
 		repoParts := strings.Split(toRepo, "/")
 		if len(repoParts) != 2 {

--- a/internal/cli/presets.go
+++ b/internal/cli/presets.go
@@ -1,0 +1,333 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mrz1836/go-broadcast/internal/config"
+	"github.com/mrz1836/go-broadcast/internal/db"
+	"github.com/mrz1836/go-broadcast/internal/output"
+)
+
+// presetSourceDB indicates a preset stored in the local database.
+const presetSourceDB = "db"
+
+// presetSourceConfigPrefix is the prefix used for presets defined in a config file.
+const presetSourceConfigPrefix = "config-file:"
+
+// presetSourceBundled indicates a preset compiled into the binary.
+const presetSourceBundled = "bundled-default"
+
+// presetListEntry is a single row in `presets list` output.
+type presetListEntry struct {
+	ID     string `json:"id"`
+	Name   string `json:"name,omitempty"`
+	Source string `json:"source"`
+}
+
+// presetSeedSummary is the JSON-shaped result of `presets seed`.
+type presetSeedSummary struct {
+	BundledSeeded int    `json:"bundled_seeded"`
+	LoadedFromDir int    `json:"loaded_from_dir"`
+	Overrides     int    `json:"overrides"`
+	FromDir       string `json:"from_dir,omitempty"`
+}
+
+// newPresetsCmd creates the top-level "presets" command with discovery subcommands.
+func newPresetsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "presets",
+		Short: "Discover and seed repository settings presets",
+		Long: `List and seed repository settings presets across all resolution sources.
+
+Resolution chain (highest priority first):
+  1. Database
+  2. Config file (--config sync.yaml)
+  3. Bundled defaults shipped with the binary (mvp, go-lib)
+
+The reserved id "default" always resolves to the hardcoded fallback preset.`,
+	}
+
+	cmd.AddCommand(newPresetsListCmd())
+	cmd.AddCommand(newPresetsSeedCmd())
+
+	return cmd
+}
+
+func newPresetsListCmd() *cobra.Command {
+	var (
+		jsonOutput bool
+		showSource bool
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List presets across all sources",
+		Long: `List every preset known to go-broadcast across the database, the configuration
+file, and the bundled defaults.
+
+With --show-source, each entry is annotated with its origin (db, config-file:<path>,
+or bundled-default). When the same id appears in multiple sources, every occurrence
+is listed so the resolution chain is fully visible.`,
+		Example: `  # List preset ids only
+  go-broadcast presets list
+
+  # Annotate each entry with the resolution source
+  go-broadcast presets list --show-source
+
+  # JSON output for scripting
+  go-broadcast presets list --json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPresetsList(cmd.Context(), showSource, jsonOutput)
+		},
+	}
+	cmd.Flags().BoolVar(&showSource, "show-source", false, "Annotate each preset with its resolution source")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	return cmd
+}
+
+// runPresetsList aggregates preset entries across DB, config file, and bundled defaults.
+func runPresetsList(ctx context.Context, showSource, jsonOutput bool) error {
+	entries := make([]presetListEntry, 0, 8)
+
+	// Database (best-effort: an unopenable database is treated as empty)
+	if database, err := openDatabase(); err == nil {
+		presetRepo := db.NewSettingsPresetRepository(database.DB())
+		dbPresets, listErr := presetRepo.List(ctx)
+		_ = database.Close()
+		if listErr != nil {
+			return printErrorResponse("preset", "listed", listErr.Error(), "", jsonOutput)
+		}
+		for _, p := range dbPresets {
+			entries = append(entries, presetListEntry{
+				ID:     p.ExternalID,
+				Name:   p.Name,
+				Source: presetSourceDB,
+			})
+		}
+	}
+
+	// Config file (best-effort: missing file is silently skipped)
+	configPath := globalFlags.ConfigFile
+	if cfg, err := config.Load(configPath); err == nil {
+		for i := range cfg.SettingsPresets {
+			p := &cfg.SettingsPresets[i]
+			entries = append(entries, presetListEntry{
+				ID:     p.ID,
+				Name:   p.Name,
+				Source: presetSourceConfigPrefix + configPath,
+			})
+		}
+	}
+
+	// Bundled defaults (always present)
+	for _, bp := range BundledPresets() {
+		entries = append(entries, presetListEntry{
+			ID:     bp.ID,
+			Name:   bp.Name,
+			Source: presetSourceBundled,
+		})
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].ID != entries[j].ID {
+			return entries[i].ID < entries[j].ID
+		}
+		return entries[i].Source < entries[j].Source
+	})
+
+	resp := CLIResponse{
+		Success: true,
+		Action:  "listed",
+		Type:    "preset",
+		Data:    entries,
+		Count:   len(entries),
+	}
+
+	if jsonOutput {
+		return printResponse(resp, true)
+	}
+
+	output.Info(fmt.Sprintf("Found %d preset(s):", len(entries)))
+	for _, e := range entries {
+		if showSource {
+			output.Info(fmt.Sprintf("  %s\t%s", e.ID, e.Source))
+		} else {
+			output.Info(fmt.Sprintf("  %s", e.ID))
+		}
+	}
+	return nil
+}
+
+func newPresetsSeedCmd() *cobra.Command {
+	var (
+		jsonOutput bool
+		fromDir    string
+	)
+	cmd := &cobra.Command{
+		Use:   "seed",
+		Short: "Seed bundled defaults (and optionally external preset files) into the database",
+		Long: `Seed the bundled generic defaults (mvp, go-lib) into the database.
+
+Always idempotent: existing rows with the same id are kept untouched. With
+--from <dir>, every *.yaml/*.yml/*.json file in the supplied directory is also
+parsed as a preset and upserted into the database. Conflicts with bundled
+defaults override the existing row and emit an INFO log entry.`,
+		Example: `  # Seed bundled defaults (idempotent)
+  go-broadcast presets seed
+
+  # Seed bundled defaults plus every preset file in a directory
+  go-broadcast presets seed --from ./my-presets/
+
+  # Verify what landed in the database afterwards
+  go-broadcast presets list --show-source`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPresetsSeed(cmd.Context(), fromDir, jsonOutput)
+		},
+	}
+	cmd.Flags().StringVar(&fromDir, "from", "", "Directory containing preset YAML/JSON files to load")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runPresetsSeed(ctx context.Context, fromDir string, jsonOutput bool) error {
+	database, err := openDatabase()
+	if err != nil {
+		return printErrorResponse("preset", "seeded", err.Error(),
+			"run 'go-broadcast db init' to create a database", jsonOutput)
+	}
+	defer func() { _ = database.Close() }()
+
+	presetRepo := db.NewSettingsPresetRepository(database.DB())
+
+	bundled := BundledPresets()
+	dbPresets := make([]*db.SettingsPreset, 0, len(bundled))
+	for i := range bundled {
+		dbPresets = append(dbPresets, configPresetToDBPreset(&bundled[i]))
+	}
+
+	bundledSeeded, err := presetRepo.SeedIfMissing(ctx, dbPresets)
+	if err != nil {
+		return printErrorResponse("preset", "seeded", err.Error(), "", jsonOutput)
+	}
+
+	summary := presetSeedSummary{BundledSeeded: bundledSeeded}
+
+	if fromDir != "" {
+		summary.FromDir = fromDir
+		loaded, overrides, loadErr := loadPresetsFromDir(ctx, presetRepo, fromDir)
+		if loadErr != nil {
+			return printErrorResponse("preset", "seeded", loadErr.Error(),
+				"check the directory contents and YAML/JSON syntax", jsonOutput)
+		}
+		summary.LoadedFromDir = loaded
+		summary.Overrides = overrides
+	}
+
+	resp := CLIResponse{
+		Success: true,
+		Action:  "seeded",
+		Type:    "preset",
+		Data:    summary,
+	}
+
+	if jsonOutput {
+		return printResponse(resp, true)
+	}
+
+	if fromDir == "" {
+		output.Info(fmt.Sprintf("Seeded %d bundled preset(s)", summary.BundledSeeded))
+	} else {
+		output.Info(fmt.Sprintf("Seeded %d bundled, loaded %d from %s (%d overrides)",
+			summary.BundledSeeded, summary.LoadedFromDir, summary.FromDir, summary.Overrides))
+	}
+	return nil
+}
+
+// loadPresetsFromDir walks dir for *.yaml/*.yml/*.json files, parses each as a SettingsPreset,
+// and upserts it into the database. Returns (loaded, overrides, error).
+func loadPresetsFromDir(ctx context.Context, presetRepo db.SettingsPresetRepository, dir string) (int, int, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to stat directory: %w", err)
+	}
+	if !info.IsDir() {
+		return 0, 0, fmt.Errorf("--from %q is not a directory", dir) //nolint:err113 // user-facing CLI error
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	bundledIDs := map[string]struct{}{}
+	for _, bp := range BundledPresets() {
+		bundledIDs[bp.ID] = struct{}{}
+	}
+
+	loaded := 0
+	overrides := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		preset, parseErr := parsePresetFile(path)
+		if parseErr != nil {
+			return loaded, overrides, fmt.Errorf("preset file %s: %w", path, parseErr)
+		}
+		if preset.ID == "" {
+			return loaded, overrides, fmt.Errorf("preset file %s: missing required field 'id'", path) //nolint:err113 // user-facing CLI error
+		}
+
+		dbPreset := configPresetToDBPreset(preset)
+		if _, lookupErr := presetRepo.GetByExternalID(ctx, preset.ID); lookupErr == nil {
+			overrides++
+			if _, isBundled := bundledIDs[preset.ID]; isBundled {
+				logrus.WithField("preset", preset.ID).Info("overriding bundled default with preset from --from directory")
+			} else {
+				logrus.WithField("preset", preset.ID).Info("overriding existing preset with preset from --from directory")
+			}
+		} else if !errors.Is(lookupErr, db.ErrRecordNotFound) {
+			return loaded, overrides, fmt.Errorf("failed to check preset %q: %w", preset.ID, lookupErr)
+		}
+
+		if importErr := presetRepo.ImportFromConfig(ctx, dbPreset); importErr != nil {
+			return loaded, overrides, fmt.Errorf("failed to import preset %q: %w", preset.ID, importErr)
+		}
+		loaded++
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"loaded":    loaded,
+		"overrides": overrides,
+		"dir":       dir,
+	}).Info("loaded presets from directory")
+
+	return loaded, overrides, nil
+}
+
+// parsePresetFile decodes a single preset definition from a YAML or JSON file.
+func parsePresetFile(path string) (*config.SettingsPreset, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-supplied directory of preset files
+	if err != nil {
+		return nil, fmt.Errorf("failed to read: %w", err)
+	}
+	var preset config.SettingsPreset
+	if err := yaml.Unmarshal(data, &preset); err != nil {
+		return nil, fmt.Errorf("failed to parse: %w", err)
+	}
+	return &preset, nil
+}

--- a/internal/cli/presets_bundled.go
+++ b/internal/cli/presets_bundled.go
@@ -1,0 +1,99 @@
+package cli
+
+import "github.com/mrz1836/go-broadcast/internal/config"
+
+// MVPPreset returns a minimal generic preset suitable for any new repository.
+//
+// It enables issues, squash merging with branch deletion, and a small set of
+// common labels. No rulesets are attached so the preset works on free GitHub
+// plans without requiring branch protection.
+func MVPPreset() config.SettingsPreset {
+	return config.SettingsPreset{
+		ID:                       "mvp",
+		Name:                     "MVP",
+		Description:              "Minimal generic preset for new repositories",
+		HasIssues:                true,
+		HasWiki:                  false,
+		HasProjects:              false,
+		HasDiscussions:           false,
+		AllowSquashMerge:         true,
+		AllowMergeCommit:         false,
+		AllowRebaseMerge:         false,
+		DeleteBranchOnMerge:      true,
+		AllowAutoMerge:           true,
+		AllowUpdateBranch:        true,
+		SquashMergeCommitTitle:   "PR_TITLE",
+		SquashMergeCommitMessage: "COMMIT_MESSAGES",
+		Labels: []config.LabelSpec{
+			{Name: "bug", Color: "d73a4a", Description: "Something isn't working"},
+			{Name: "enhancement", Color: "a2eeef", Description: "New feature or request"},
+			{Name: "documentation", Color: "0075ca", Description: "Documentation improvements"},
+			{Name: "good first issue", Color: "7057ff", Description: "Good for newcomers"},
+			{Name: "help wanted", Color: "008672", Description: "Extra attention needed"},
+		},
+	}
+}
+
+// GoLibPreset returns a preset tuned for an open-source Go library.
+//
+// It layers a typical Go OSS label set and a single branch-protection ruleset
+// (default branch requires a pull request, deletion blocked) onto the MVP
+// settings. Suitable for any community Go module.
+func GoLibPreset() config.SettingsPreset {
+	return config.SettingsPreset{
+		ID:                       "go-lib",
+		Name:                     "Go Library",
+		Description:              "Standard preset for open-source Go libraries",
+		HasIssues:                true,
+		HasWiki:                  false,
+		HasProjects:              false,
+		HasDiscussions:           true,
+		AllowSquashMerge:         true,
+		AllowMergeCommit:         false,
+		AllowRebaseMerge:         false,
+		DeleteBranchOnMerge:      true,
+		AllowAutoMerge:           true,
+		AllowUpdateBranch:        true,
+		SquashMergeCommitTitle:   "PR_TITLE",
+		SquashMergeCommitMessage: "COMMIT_MESSAGES",
+		Rulesets: []config.RulesetConfig{
+			{
+				Name:        "branch-protection",
+				Target:      "branch",
+				Enforcement: "active",
+				Include:     []string{"~DEFAULT_BRANCH"},
+				Rules:       []string{"deletion", "pull_request"},
+			},
+			{
+				Name:        "tag-protection",
+				Target:      "tag",
+				Enforcement: "active",
+				Include:     []string{"~ALL"},
+				Rules:       []string{"deletion", "update"},
+			},
+		},
+		Labels: []config.LabelSpec{
+			{Name: "bug", Color: "d73a4a", Description: "Something isn't working"},
+			{Name: "enhancement", Color: "a2eeef", Description: "New feature or request"},
+			{Name: "documentation", Color: "0075ca", Description: "Documentation improvements"},
+			{Name: "good first issue", Color: "7057ff", Description: "Good for newcomers"},
+			{Name: "help wanted", Color: "008672", Description: "Extra attention needed"},
+			{Name: "dependencies", Color: "0366d6", Description: "Pull requests that update a dependency file"},
+			{Name: "go", Color: "00ADD8", Description: "Go-related changes"},
+			{Name: "tests", Color: "fbca04", Description: "Test additions or fixes"},
+			{Name: "ci", Color: "5319e7", Description: "Continuous integration changes"},
+			{Name: "breaking-change", Color: "b60205", Description: "Backwards-incompatible change"},
+		},
+	}
+}
+
+// BundledPresets returns the set of generic presets shipped with go-broadcast.
+//
+// The slice order is the canonical seeding order: callers can rely on
+// BundledPresets()[0] being the MVP preset and [1] being the Go library preset.
+func BundledPresets() []config.SettingsPreset {
+	return []config.SettingsPreset{
+		MVPPreset(),
+		GoLibPreset(),
+	}
+}

--- a/internal/cli/presets_test.go
+++ b/internal/cli/presets_test.go
@@ -1,0 +1,234 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mrz1836/go-broadcast/internal/db"
+)
+
+// withEmptyConfigPath points the global config flag at an empty file inside
+// t.TempDir() so config.Load returns no presets without polluting the working
+// directory. Returns a restore function.
+func withEmptyConfigPath(t *testing.T) func() {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "empty-sync.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("version: 1\ngroups: []\n"), 0o600))
+	old := globalFlags.ConfigFile
+	globalFlags.ConfigFile = path
+	return func() { globalFlags.ConfigFile = old }
+}
+
+// writePresetYAML writes a single preset YAML file to dir and returns its path.
+func writePresetYAML(t *testing.T, dir, filename, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, filename)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func TestBundledPresets_AreGenericAndStable(t *testing.T) {
+	bundled := BundledPresets()
+	require.Len(t, bundled, 2)
+	assert.Equal(t, "mvp", bundled[0].ID)
+	assert.Equal(t, "go-lib", bundled[1].ID)
+	for _, p := range bundled {
+		assert.NotEmpty(t, p.Name)
+		assert.NotEmpty(t, p.Description)
+		assert.NotEmpty(t, p.Labels, "preset %q should ship default labels", p.ID)
+	}
+}
+
+func TestRunPresetsList_AggregatesAllSources(t *testing.T) {
+	cleanupDB := setupPresetTestDB(t)
+	defer cleanupDB()
+	cleanupCfg := withEmptyConfigPath(t)
+	defer cleanupCfg()
+
+	// Seed a single DB-only preset so we can prove the DB row is captured.
+	database, err := db.Open(db.OpenOptions{Path: dbPath, AutoMigrate: true})
+	require.NoError(t, err)
+	presetRepo := db.NewSettingsPresetRepository(database.DB())
+	require.NoError(t, presetRepo.Create(context.Background(), &db.SettingsPreset{
+		ExternalID: "team-only",
+		Name:       "Team Only",
+	}))
+	require.NoError(t, database.Close())
+
+	resp, err := captureJSON(t, func() error {
+		return runPresetsList(context.Background(), true, true)
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	assert.Equal(t, "preset", resp.Type)
+
+	entries, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected list payload, got %T", resp.Data)
+	require.GreaterOrEqual(t, len(entries), 3, "expected DB row + 2 bundled defaults")
+
+	// Collect (id, source) pairs for assertions
+	type seen struct{ id, source string }
+	got := make([]seen, 0, len(entries))
+	for _, e := range entries {
+		m, ok := e.(map[string]interface{})
+		require.True(t, ok)
+		got = append(got, seen{
+			id:     m["id"].(string),
+			source: m["source"].(string),
+		})
+	}
+
+	hasSource := func(id, source string) bool {
+		for _, s := range got {
+			if s.id == id && s.source == source {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, hasSource("team-only", presetSourceDB), "team-only should appear with db source")
+	assert.True(t, hasSource("mvp", presetSourceBundled), "mvp should appear as bundled-default")
+	assert.True(t, hasSource("go-lib", presetSourceBundled), "go-lib should appear as bundled-default")
+}
+
+func TestRunPresetsSeed_Idempotent(t *testing.T) {
+	cleanup := setupPresetTestDB(t)
+	defer cleanup()
+
+	// First seed: creates 2 bundled rows
+	resp, err := captureJSON(t, func() error {
+		return runPresetsSeed(context.Background(), "", true)
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	data := resp.Data.(map[string]interface{})
+	assert.InDelta(t, 2.0, data["bundled_seeded"], 0.0001)
+
+	// Second seed: 0 bundled rows added (idempotent)
+	resp, err = captureJSON(t, func() error {
+		return runPresetsSeed(context.Background(), "", true)
+	})
+	require.NoError(t, err)
+	data = resp.Data.(map[string]interface{})
+	assert.InDelta(t, 0.0, data["bundled_seeded"], 0.0001)
+
+	// DB total should be exactly 2
+	database, err := db.Open(db.OpenOptions{Path: dbPath, AutoMigrate: true})
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+	presets, err := db.NewSettingsPresetRepository(database.DB()).List(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, presets, 2)
+}
+
+func TestRunPresetsSeed_FromDir(t *testing.T) {
+	cleanup := setupPresetTestDB(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	writePresetYAML(t, dir, "team.yaml", `
+id: team-defaults
+name: Team Defaults
+description: Custom team preset
+has_issues: true
+allow_squash_merge: true
+delete_branch_on_merge: true
+labels:
+  - name: chore
+    color: cccccc
+    description: Maintenance work
+`)
+
+	resp, err := captureJSON(t, func() error {
+		return runPresetsSeed(context.Background(), dir, true)
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	data := resp.Data.(map[string]interface{})
+	assert.InDelta(t, 2.0, data["bundled_seeded"], 0.0001)
+	assert.InDelta(t, 1.0, data["loaded_from_dir"], 0.0001)
+	assert.InDelta(t, 0.0, data["overrides"], 0.0001)
+	assert.Equal(t, dir, data["from_dir"])
+
+	// Re-running is idempotent: bundled stays at 0, dir count is 1, but it now
+	// counts as an override against the previously-imported row.
+	resp, err = captureJSON(t, func() error {
+		return runPresetsSeed(context.Background(), dir, true)
+	})
+	require.NoError(t, err)
+	data = resp.Data.(map[string]interface{})
+	assert.InDelta(t, 0.0, data["bundled_seeded"], 0.0001)
+	assert.InDelta(t, 1.0, data["loaded_from_dir"], 0.0001)
+	assert.InDelta(t, 1.0, data["overrides"], 0.0001)
+
+	// DB total should be exactly 3 (2 bundled + 1 custom)
+	database, err := db.Open(db.OpenOptions{Path: dbPath, AutoMigrate: true})
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+	presets, err := db.NewSettingsPresetRepository(database.DB()).List(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, presets, 3)
+}
+
+func TestRunPresetsSeed_FromDir_OverrideBundled(t *testing.T) {
+	cleanup := setupPresetTestDB(t)
+	defer cleanup()
+
+	// Pre-seed bundled defaults so the next --from import is an override.
+	_, err := captureJSON(t, func() error {
+		return runPresetsSeed(context.Background(), "", true)
+	})
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	writePresetYAML(t, dir, "mvp.yaml", `
+id: mvp
+name: MVP Override
+description: Locally-modified mvp preset
+has_issues: false
+allow_squash_merge: true
+delete_branch_on_merge: true
+labels:
+  - name: priority
+    color: ff0000
+    description: Top priority
+`)
+
+	resp, err := captureJSON(t, func() error {
+		return runPresetsSeed(context.Background(), dir, true)
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	data := resp.Data.(map[string]interface{})
+	assert.InDelta(t, 1.0, data["loaded_from_dir"], 0.0001)
+	assert.InDelta(t, 1.0, data["overrides"], 0.0001)
+
+	// Confirm the bundled mvp row was overridden in the DB.
+	database, err := db.Open(db.OpenOptions{Path: dbPath, AutoMigrate: true})
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+	mvp, err := db.NewSettingsPresetRepository(database.DB()).GetByExternalID(context.Background(), "mvp")
+	require.NoError(t, err)
+	assert.Equal(t, "MVP Override", mvp.Name)
+	assert.False(t, mvp.HasIssues, "override should drive HasIssues to false")
+	require.Len(t, mvp.Labels, 1)
+	assert.Equal(t, "priority", mvp.Labels[0].Name)
+}
+
+func TestParsePresetFile_MissingID(t *testing.T) {
+	dir := t.TempDir()
+	path := writePresetYAML(t, dir, "no-id.yaml", `
+name: Nameless
+description: Missing id field
+`)
+
+	preset, err := parsePresetFile(path)
+	require.NoError(t, err)
+	assert.Empty(t, preset.ID, "parser tolerates missing id; loader rejects it")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -107,6 +107,7 @@ func init() {
 	rootCmd.AddCommand(metricsCmd)
 	rootCmd.AddCommand(newScaffoldCmd())
 	rootCmd.AddCommand(newSettingsCmd())
+	rootCmd.AddCommand(newPresetsCmd())
 }
 
 // NewRootCmd creates a new isolated root command instance for testing

--- a/internal/cli/scaffold.go
+++ b/internal/cli/scaffold.go
@@ -15,6 +15,10 @@ import (
 	"github.com/mrz1836/go-broadcast/internal/output"
 )
 
+// reservedDefaultPresetID is the literal id that explicitly resolves to the
+// hardcoded fallback preset returned by config.DefaultPreset().
+const reservedDefaultPresetID = "default"
+
 // newScaffoldCmd creates the "scaffold" command
 func newScaffoldCmd() *cobra.Command {
 	var (
@@ -67,8 +71,11 @@ func runScaffold(ctx context.Context, repoName, desc, presetID, topics, _ string
 		return fmt.Errorf("invalid repo format %q, expected owner/name", repoName) //nolint:err113 // user-facing
 	}
 
-	// Resolve preset: try DB first, fall back to config, then hardcoded default
-	preset := resolvePreset(ctx, presetID)
+	// Resolve preset: try DB first, fall back to config, then bundled defaults
+	preset, err := resolvePreset(ctx, presetID)
+	if err != nil {
+		return err
+	}
 
 	// Parse topics
 	var topicList []string
@@ -92,7 +99,7 @@ func runScaffold(ctx context.Context, repoName, desc, presetID, topics, _ string
 
 	if dryRun {
 		// No need for a real GH client in dry-run mode
-		_, err := RunScaffold(ctx, nil, opts)
+		_, err = RunScaffold(ctx, nil, opts)
 		return err
 	}
 
@@ -112,58 +119,107 @@ func runScaffold(ctx context.Context, repoName, desc, presetID, topics, _ string
 	return nil
 }
 
-// resolvePreset looks up a preset from DB first, then config file, then falls back to default
-func resolvePreset(ctx context.Context, presetID string) *config.SettingsPreset {
-	// Try DB lookup
+// resolvePreset looks up a preset across the resolution chain (DB → config file
+// → bundled defaults) and returns it. The reserved id "default" always
+// resolves to the hardcoded fallback returned by config.DefaultPreset().
+//
+// On first use against an empty preset table, the bundled generic defaults are
+// auto-seeded so subsequent lookups can find them. An unknown id returns a
+// helpful error rather than silently forging a placeholder preset.
+func resolvePreset(ctx context.Context, presetID string) (*config.SettingsPreset, error) {
+	// Reserved id always resolves to the hardcoded fallback preset.
+	if presetID == reservedDefaultPresetID {
+		dflt := config.DefaultPreset()
+		dflt.ID = reservedDefaultPresetID
+		return &dflt, nil
+	}
+
+	// Try DB lookup (auto-seed bundled defaults if the preset table is empty).
 	database, err := openDatabase()
 	if err == nil {
 		defer func() { _ = database.Close() }()
 		presetRepo := db.NewSettingsPresetRepository(database.DB())
+
+		autoSeedBundledIfEmpty(ctx, presetRepo)
+
 		dbPreset, dbErr := presetRepo.GetByExternalID(ctx, presetID)
 		if dbErr == nil {
-			// Convert DB preset to config preset
-			compat := &dbSettingsPresetCompat{
-				ExternalID:               dbPreset.ExternalID,
-				Name:                     dbPreset.Name,
-				Description:              dbPreset.Description,
-				HasIssues:                dbPreset.HasIssues,
-				HasWiki:                  dbPreset.HasWiki,
-				HasProjects:              dbPreset.HasProjects,
-				HasDiscussions:           dbPreset.HasDiscussions,
-				AllowSquashMerge:         dbPreset.AllowSquashMerge,
-				AllowMergeCommit:         dbPreset.AllowMergeCommit,
-				AllowRebaseMerge:         dbPreset.AllowRebaseMerge,
-				DeleteBranchOnMerge:      dbPreset.DeleteBranchOnMerge,
-				AllowAutoMerge:           dbPreset.AllowAutoMerge,
-				AllowUpdateBranch:        dbPreset.AllowUpdateBranch,
-				SquashMergeCommitTitle:   dbPreset.SquashMergeCommitTitle,
-				SquashMergeCommitMessage: dbPreset.SquashMergeCommitMessage,
-			}
-			for _, l := range dbPreset.Labels {
-				compat.Labels = append(compat.Labels, dbLabelCompat{
-					Name: l.Name, Color: l.Color, Description: l.Description,
-				})
-			}
-			for _, r := range dbPreset.Rulesets {
-				compat.Rulesets = append(compat.Rulesets, dbRulesetCompat{
-					Name: r.Name, Target: r.Target, Enforcement: r.Enforcement,
-					Include: []string(r.Include), Exclude: []string(r.Exclude), Rules: []string(r.Rules),
-				})
-			}
-			return dbPresetToConfigPreset(compat)
+			return dbPresetToResolved(dbPreset), nil
 		}
 	}
 
-	// Try config file
-	cfg, cfgErr := config.Load(globalFlags.ConfigFile)
-	if cfgErr == nil {
+	// Try config file.
+	if cfg, cfgErr := config.Load(globalFlags.ConfigFile); cfgErr == nil {
 		if p := cfg.GetPreset(presetID); p != nil {
-			return p
+			return p, nil
 		}
 	}
 
-	// Fall back to hardcoded default
-	dflt := config.DefaultPreset()
-	dflt.ID = presetID
-	return &dflt
+	// Try bundled defaults.
+	for _, bp := range BundledPresets() {
+		if bp.ID == presetID {
+			preset := bp
+			return &preset, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unknown preset: %s (run 'go-broadcast presets list' to see available)", presetID) //nolint:err113 // user-facing CLI error
+}
+
+// autoSeedBundledIfEmpty seeds the bundled defaults into the preset table when
+// the table is empty. Errors are logged but do not block resolution.
+func autoSeedBundledIfEmpty(ctx context.Context, presetRepo db.SettingsPresetRepository) {
+	existing, listErr := presetRepo.List(ctx)
+	if listErr != nil || len(existing) > 0 {
+		return
+	}
+
+	bundled := BundledPresets()
+	dbPresets := make([]*db.SettingsPreset, 0, len(bundled))
+	for i := range bundled {
+		dbPresets = append(dbPresets, configPresetToDBPreset(&bundled[i]))
+	}
+
+	seeded, seedErr := presetRepo.SeedIfMissing(ctx, dbPresets)
+	if seedErr != nil {
+		logrus.WithError(seedErr).Warn("failed to auto-seed bundled presets")
+		return
+	}
+	if seeded > 0 {
+		logrus.WithField("count", seeded).Info("auto-seeded bundled preset(s) into empty DB")
+	}
+}
+
+// dbPresetToResolved converts a stored db.SettingsPreset into the config-level
+// SettingsPreset returned by resolvePreset.
+func dbPresetToResolved(dbPreset *db.SettingsPreset) *config.SettingsPreset {
+	compat := &dbSettingsPresetCompat{
+		ExternalID:               dbPreset.ExternalID,
+		Name:                     dbPreset.Name,
+		Description:              dbPreset.Description,
+		HasIssues:                dbPreset.HasIssues,
+		HasWiki:                  dbPreset.HasWiki,
+		HasProjects:              dbPreset.HasProjects,
+		HasDiscussions:           dbPreset.HasDiscussions,
+		AllowSquashMerge:         dbPreset.AllowSquashMerge,
+		AllowMergeCommit:         dbPreset.AllowMergeCommit,
+		AllowRebaseMerge:         dbPreset.AllowRebaseMerge,
+		DeleteBranchOnMerge:      dbPreset.DeleteBranchOnMerge,
+		AllowAutoMerge:           dbPreset.AllowAutoMerge,
+		AllowUpdateBranch:        dbPreset.AllowUpdateBranch,
+		SquashMergeCommitTitle:   dbPreset.SquashMergeCommitTitle,
+		SquashMergeCommitMessage: dbPreset.SquashMergeCommitMessage,
+	}
+	for _, l := range dbPreset.Labels {
+		compat.Labels = append(compat.Labels, dbLabelCompat{
+			Name: l.Name, Color: l.Color, Description: l.Description,
+		})
+	}
+	for _, r := range dbPreset.Rulesets {
+		compat.Rulesets = append(compat.Rulesets, dbRulesetCompat{
+			Name: r.Name, Target: r.Target, Enforcement: r.Enforcement,
+			Include: []string(r.Include), Exclude: []string(r.Exclude), Rules: []string(r.Rules),
+		})
+	}
+	return dbPresetToConfigPreset(compat)
 }

--- a/internal/cli/scaffold_test.go
+++ b/internal/cli/scaffold_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mrz1836/go-broadcast/internal/config"
+	"github.com/mrz1836/go-broadcast/internal/db"
 	"github.com/mrz1836/go-broadcast/internal/gh"
 )
 
@@ -266,4 +267,73 @@ func TestDbPresetToConfigPreset(t *testing.T) {
 	assert.Equal(t, "bug", preset.Labels[0].Name)
 	require.Len(t, preset.Rulesets, 1)
 	assert.Equal(t, "branch-protection", preset.Rulesets[0].Name)
+}
+
+func TestResolvePreset_DefaultReservedID(t *testing.T) {
+	cleanup := setupPresetTestDB(t)
+	defer cleanup()
+	cleanupCfg := withEmptyConfigPath(t)
+	defer cleanupCfg()
+
+	preset, err := resolvePreset(context.Background(), reservedDefaultPresetID)
+	require.NoError(t, err)
+	require.NotNil(t, preset)
+	assert.Equal(t, reservedDefaultPresetID, preset.ID,
+		"reserved id should resolve to DefaultPreset() with id=default")
+	assert.NotEmpty(t, preset.Labels, "DefaultPreset ships labels")
+}
+
+func TestResolvePreset_UnknownIDErrors(t *testing.T) {
+	cleanup := setupPresetTestDB(t)
+	defer cleanup()
+	cleanupCfg := withEmptyConfigPath(t)
+	defer cleanupCfg()
+
+	preset, err := resolvePreset(context.Background(), "nonexistent-xyz-typo")
+	require.Error(t, err)
+	assert.Nil(t, preset)
+	assert.Contains(t, err.Error(), "unknown preset:")
+	assert.Contains(t, err.Error(), "presets list")
+}
+
+func TestResolvePreset_AutoSeedsEmptyDB(t *testing.T) {
+	cleanup := setupPresetTestDB(t)
+	defer cleanup()
+	cleanupCfg := withEmptyConfigPath(t)
+	defer cleanupCfg()
+
+	// DB starts empty; resolving a bundled id should auto-seed and return it.
+	preset, err := resolvePreset(context.Background(), "mvp")
+	require.NoError(t, err)
+	require.NotNil(t, preset)
+	assert.Equal(t, "mvp", preset.ID)
+
+	// DB should now contain the bundled rows.
+	database, err := db.Open(db.OpenOptions{Path: dbPath, AutoMigrate: true})
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+	rows, err := db.NewSettingsPresetRepository(database.DB()).List(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, rows, len(BundledPresets()), "auto-seed populates every bundled default")
+}
+
+func TestResolvePreset_DBPriorityOverBundled(t *testing.T) {
+	cleanup := setupPresetTestDB(t)
+	defer cleanup()
+	cleanupCfg := withEmptyConfigPath(t)
+	defer cleanupCfg()
+
+	// Pre-insert an mvp row whose name would never come from the bundled default.
+	database, err := db.Open(db.OpenOptions{Path: dbPath, AutoMigrate: true})
+	require.NoError(t, err)
+	require.NoError(t, db.NewSettingsPresetRepository(database.DB()).Create(
+		context.Background(),
+		&db.SettingsPreset{ExternalID: "mvp", Name: "MVP from DB", Description: "DB-resident override"},
+	))
+	require.NoError(t, database.Close())
+
+	preset, err := resolvePreset(context.Background(), "mvp")
+	require.NoError(t, err)
+	require.NotNil(t, preset)
+	assert.Equal(t, "MVP from DB", preset.Name, "DB row should win over bundled default")
 }

--- a/internal/cli/settings_apply.go
+++ b/internal/cli/settings_apply.go
@@ -72,7 +72,10 @@ func runSettingsApply(ctx context.Context, repo, presetID, topics, description s
 	}
 
 	// Resolve preset
-	preset := resolvePreset(ctx, presetID)
+	preset, err := resolvePreset(ctx, presetID)
+	if err != nil {
+		return err
+	}
 
 	output.Info(fmt.Sprintf("Settings apply: %s (preset: %s)", repo, preset.ID))
 

--- a/internal/cli/settings_audit.go
+++ b/internal/cli/settings_audit.go
@@ -193,8 +193,18 @@ func runSettingsAudit(ctx context.Context, repos []string, presetID, org string,
 }
 
 func auditSingleRepo(ctx context.Context, ghClient gh.Client, repo, presetID string) auditResult {
-	// Resolve preset for this repo
-	preset := resolvePreset(ctx, presetID)
+	// Resolve preset for this repo. An empty --preset flag falls back to the
+	// generic mvp default to match the documented "default: repo's assigned
+	// preset or mvp" behavior without re-introducing silent forging for
+	// arbitrary unknown ids.
+	resolveID := presetID
+	if resolveID == "" {
+		resolveID = "mvp"
+	}
+	preset, err := resolvePreset(ctx, resolveID)
+	if err != nil {
+		return auditResult{Repo: repo, Preset: presetID, Error: err.Error()}
+	}
 	if presetID == "" {
 		presetID = preset.ID
 	}

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -121,6 +121,9 @@ type SettingsPresetRepository interface {
 	AssignPresetToRepo(ctx context.Context, repoID, presetID uint) error
 	// GetPresetForRepo returns the assigned preset or nil
 	GetPresetForRepo(ctx context.Context, repoID uint) (*SettingsPreset, error)
+	// SeedIfMissing creates each preset only when no row exists with the same ExternalID.
+	// Returns the count of newly-seeded presets. Idempotent.
+	SeedIfMissing(ctx context.Context, presets []*SettingsPreset) (int, error)
 }
 
 // QueryRepository provides cross-entity query operations

--- a/internal/db/repository_settings_preset.go
+++ b/internal/db/repository_settings_preset.go
@@ -180,6 +180,39 @@ func (r *settingsPresetRepository) AssignPresetToRepo(ctx context.Context, repoI
 	return nil
 }
 
+// SeedIfMissing creates any preset whose ExternalID is not already present in the DB.
+// Returns the count of newly-seeded presets. Idempotent.
+func (r *settingsPresetRepository) SeedIfMissing(ctx context.Context, presets []*SettingsPreset) (int, error) {
+	seeded := 0
+	for _, preset := range presets {
+		if preset == nil {
+			continue
+		}
+		_, err := r.GetByExternalID(ctx, preset.ExternalID)
+		if err == nil {
+			continue // already exists, skip
+		}
+		if !errors.Is(err, ErrRecordNotFound) {
+			return seeded, fmt.Errorf("failed to check preset %q: %w", preset.ExternalID, err)
+		}
+		// Reset IDs so GORM creates a fresh row (callers may pass reusable templates)
+		preset.ID = 0
+		for i := range preset.Labels {
+			preset.Labels[i].ID = 0
+			preset.Labels[i].SettingsPresetID = 0
+		}
+		for i := range preset.Rulesets {
+			preset.Rulesets[i].ID = 0
+			preset.Rulesets[i].SettingsPresetID = 0
+		}
+		if err := r.Create(ctx, preset); err != nil {
+			return seeded, fmt.Errorf("failed to seed preset %q: %w", preset.ExternalID, err)
+		}
+		seeded++
+	}
+	return seeded, nil
+}
+
 // GetPresetForRepo returns the assigned preset or nil
 func (r *settingsPresetRepository) GetPresetForRepo(ctx context.Context, repoID uint) (*SettingsPreset, error) {
 	var repo Repo


### PR DESCRIPTION
## Overview

Makes `go-broadcast` preset resolution transparent and self-documenting. Adds
two bundled generic defaults (`mvp`, `go-lib`), a `presets` command for
listing and seeding, an auto-seed on the first preset-resolving command
against an empty database, a clearer `db status` pointer, and dedicated
documentation in `docs/presets.md`.

This also fixes a long-standing footgun where `--preset <typo>` would
silently succeed by forging the default preset under the requested id; the
command now errors with `unknown preset: <id> (run 'go-broadcast presets list' to see available)`.

## Changes

### New CLI surface
- `go-broadcast presets list [--show-source] [--json]` aggregates presets
  across the database, the configured config file, and the bundled
  defaults compiled into the binary.
- `go-broadcast presets seed [--from <dir>] [--json]` idempotently seeds
  the bundled defaults and, with `--from`, ingests every `*.yaml`,
  `*.yml`, and `*.json` file in the supplied directory as a preset
  definition. Conflicts override the existing row and emit an INFO log.

### Bundled defaults
- `mvp` — minimal generic preset (issues + squash merge + small label set).
- `go-lib` — open-source Go library preset with branch and tag protection
  and a typical Go OSS label set.
- Both ship as Go data inside the binary so any fork gets sensible
  out-of-the-box behaviour with zero external configuration.

### Resolution chain rework
- Reserved id `default` always resolves to `config.DefaultPreset()`.
- Lookups follow DB → config file → bundled defaults; the first match wins.
- An empty preset table is auto-seeded with the bundled defaults on first
  use (`auto-seeded N bundled preset(s) into empty DB` at INFO).
- **Behaviour change:** unknown ids now error out instead of silently
  resolving to a forged default. This is the headline UX fix and is
  documented in `docs/presets.md`. Existing callers that used `--preset` with
  a literal id continue to work; only typos and references to non-existent
  ids surface the new error.

### `db status` pointer
- Human-readable output appends `→ run 'go-broadcast presets list' for full inventory across sources` when the `settings_presets` table is present, so users can discover the cross-source view from the existing status command.

### Documentation
- New `docs/presets.md` walks through the resolution chain, the reserved
  `default` id, the bundled defaults, the `presets list --show-source`
  annotations, and the `presets seed --from` workflow with a fully generic
  example YAML.

## Testing

- `magex format:fix` and `magex lint` pass cleanly.
- `go test -race -count=1` passes for `internal/cli`, `internal/db`, and
  `internal/config`.
- New unit tests cover:
  - `presets list` aggregation across DB + config + bundled sources.
  - `presets seed` idempotency, `--from` directory ingestion, and bundled
    overrides.
  - `resolvePreset` for the reserved `default` id, unknown-id error,
    auto-seed of an empty DB, and DB-over-bundled priority.
- Coverage on the new files: `presets_bundled.go` 100%, `presets.go`
  65–100% per function, `resolvePreset` in `scaffold.go` 95.2%.

## Test plan

- [ ] `go-broadcast presets list` prints the bundled defaults on a fresh
      install.
- [ ] `go-broadcast presets list --show-source` annotates each entry with
      `db`, `config-file:<path>`, or `bundled-default`.
- [ ] `go-broadcast presets seed` is idempotent on re-run (no duplicate
      rows).
- [ ] `go-broadcast presets seed --from <dir>` loads every YAML/JSON file
      and overrides existing rows.
- [ ] `go-broadcast scaffold owner/repo "..." --preset bogus` exits with
      `unknown preset: bogus (run 'go-broadcast presets list' to see available)`.
- [ ] `go-broadcast scaffold owner/repo "..." --preset default` resolves to
      the hardcoded fallback preset.
- [ ] `go-broadcast db status` includes the one-line `presets list`
      pointer.