### PR TITLE
fix(db): honor --dry-run across db CRUD commands

### DIFF
--- a/internal/cli/db_bulk.go
+++ b/internal/cli/db_bulk.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -75,6 +76,14 @@ func runBulkAddFileList(groupExternalID, fileListExternalID string, jsonOutput b
 			"run 'go-broadcast db file-list list --json' to see available file lists", jsonOutput)
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "bulk-attached",
+			Type:   "file_list_ref",
+			Data:   bulkResult{GroupID: groupExternalID, ListID: fileListExternalID},
+		}, fmt.Sprintf("attach file list %q to all targets in group %q", fileListExternalID, groupExternalID), jsonOutput)
+	}
+
 	bulkRepo := db.NewBulkRepository(gormDB)
 	affected, err := bulkRepo.AddFileListToAllTargets(ctx, group.ID, fl.ID)
 	if err != nil {
@@ -134,6 +143,14 @@ func runBulkRemoveFileList(groupExternalID, fileListExternalID string, jsonOutpu
 	if err != nil {
 		return printErrorResponse("bulk", "remove-file-list", err.Error(),
 			"run 'go-broadcast db file-list list --json' to see available file lists", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "bulk-detached",
+			Type:   "file_list_ref",
+			Data:   bulkResult{GroupID: groupExternalID, ListID: fileListExternalID},
+		}, fmt.Sprintf("detach file list %q from all targets in group %q", fileListExternalID, groupExternalID), jsonOutput)
 	}
 
 	bulkRepo := db.NewBulkRepository(gormDB)
@@ -197,6 +214,14 @@ func runBulkAddDirList(groupExternalID, dirListExternalID string, jsonOutput boo
 			"run 'go-broadcast db dir-list list --json' to see available directory lists", jsonOutput)
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "bulk-attached",
+			Type:   "directory_list_ref",
+			Data:   bulkResult{GroupID: groupExternalID, ListID: dirListExternalID},
+		}, fmt.Sprintf("attach directory list %q to all targets in group %q", dirListExternalID, groupExternalID), jsonOutput)
+	}
+
 	bulkRepo := db.NewBulkRepository(gormDB)
 	affected, err := bulkRepo.AddDirectoryListToAllTargets(ctx, group.ID, dl.ID)
 	if err != nil {
@@ -256,6 +281,14 @@ func runBulkRemoveDirList(groupExternalID, dirListExternalID string, jsonOutput 
 	if err != nil {
 		return printErrorResponse("bulk", "remove-dir-list", err.Error(),
 			"run 'go-broadcast db dir-list list --json' to see available directory lists", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "bulk-detached",
+			Type:   "directory_list_ref",
+			Data:   bulkResult{GroupID: groupExternalID, ListID: dirListExternalID},
+		}, fmt.Sprintf("detach directory list %q from all targets in group %q", dirListExternalID, groupExternalID), jsonOutput)
 	}
 
 	bulkRepo := db.NewBulkRepository(gormDB)

--- a/internal/cli/db_crud_test.go
+++ b/internal/cli/db_crud_test.go
@@ -94,6 +94,25 @@ func setupTestDB(t *testing.T) func() {
 	}
 }
 
+func withDryRunEnabled(t *testing.T) {
+	t.Helper()
+
+	original := GetGlobalFlags()
+	SetFlags(&Flags{
+		ConfigFile:       original.ConfigFile,
+		DryRun:           true,
+		LogLevel:         original.LogLevel,
+		GroupFilter:      append([]string(nil), original.GroupFilter...),
+		SkipGroups:       append([]string(nil), original.SkipGroups...),
+		Automerge:        original.Automerge,
+		ClearModuleCache: original.ClearModuleCache,
+		FromDB:           original.FromDB,
+	})
+	t.Cleanup(func() {
+		SetFlags(original)
+	})
+}
+
 // captureJSON captures JSON output by temporarily redirecting stdout
 func captureJSON(t *testing.T, fn func() error) (CLIResponse, error) {
 	t.Helper()
@@ -365,6 +384,29 @@ func TestTargetAdd(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, resp.Success)
 		assert.Equal(t, "already_exists", resp.Action)
+	})
+
+	t.Run("dry-run does not create target", func(t *testing.T) {
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.Target{}).Count(&before).Error)
+
+		resp, err := captureJSON(t, func() error {
+			return runTargetAdd("my-tools", "acme/dry-run-target", "main", true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+		assert.Equal(t, "created", resp.Action)
+
+		var after int64
+		require.NoError(t, database.DB().Model(&db.Target{}).Count(&after).Error)
+		assert.Equal(t, before, after)
 	})
 }
 
@@ -662,6 +704,32 @@ func TestFileAdd(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, resp.Success)
+
+	t.Run("dry-run does not create file mapping", func(t *testing.T) {
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var target db.Target
+		require.NoError(t, database.DB().Where("position = ?", 0).First(&target).Error)
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.FileMapping{}).Where("owner_type = ? AND owner_id = ?", "target", target.ID).Count(&before).Error)
+
+		resp, err := captureJSON(t, func() error {
+			return runFileAdd("my-tools", "acme/test-repo-1", "LICENSE", "LICENSE", false, true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+		assert.Equal(t, "created", resp.Action)
+
+		var after int64
+		require.NoError(t, database.DB().Model(&db.FileMapping{}).Where("owner_type = ? AND owner_id = ?", "target", target.ID).Count(&after).Error)
+		assert.Equal(t, before, after)
+	})
 }
 
 func TestFileRemove(t *testing.T) {
@@ -1021,6 +1089,37 @@ func TestTargetClone(t *testing.T) {
 		require.NoError(t, gormDB.Where("owner_type = ? AND owner_id = ?", "target", target1.ID).Find(&sourceFileMappings).Error)
 		assert.Len(t, sourceFileMappings, 1)
 		assert.NotEqual(t, sourceFileMappings[0].ID, fileMappings[0].ID)
+	})
+
+	t.Run("dry-run does not clone target", func(t *testing.T) {
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.Target{}).Count(&before).Error)
+
+		cmd := newDBTargetCloneCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--from", "acme/test-repo-1",
+			"--to", "acme/dry-run-clone",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error {
+			return cmd.Execute()
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+		assert.Equal(t, "cloned", resp.Action)
+
+		var after int64
+		require.NoError(t, database.DB().Model(&db.Target{}).Count(&after).Error)
+		assert.Equal(t, before, after)
 	})
 
 	t.Run("clone with overrides", func(t *testing.T) {

--- a/internal/cli/db_crud_test.go
+++ b/internal/cli/db_crud_test.go
@@ -824,18 +824,79 @@ func TestRefAddFileList(t *testing.T) {
 		assert.True(t, resp.Success)
 		assert.Equal(t, "already_attached", resp.Action)
 	})
+
+	t.Run("dry-run does not attach file list ref", func(t *testing.T) {
+		// Create a fresh target with no existing refs so we hit the writer path,
+		// not the idempotent "already_attached" branch.
+		_, err := captureJSON(t, func() error {
+			return runTargetAdd("my-tools", "acme/ref-fl-dry-target", "main", true)
+		})
+		require.NoError(t, err)
+
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.TargetFileListRef{}).Count(&before).Error)
+
+		resp, err := captureJSON(t, func() error {
+			return runRefAddFileList("my-tools", "acme/ref-fl-dry-target", "ai-files", true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+		assert.Equal(t, "attached", resp.Action)
+
+		var after int64
+		require.NoError(t, database.DB().Model(&db.TargetFileListRef{}).Count(&after).Error)
+		assert.Equal(t, before, after)
+	})
 }
 
 func TestRefRemoveFileList(t *testing.T) {
 	cleanup := setupTestDB(t)
 	defer cleanup()
 
-	resp, err := captureJSON(t, func() error {
-		return runRefRemoveFileList("my-tools", "acme/test-repo-1", "ai-files", true)
+	t.Run("remove existing ref", func(t *testing.T) {
+		resp, err := captureJSON(t, func() error {
+			return runRefRemoveFileList("my-tools", "acme/test-repo-1", "ai-files", true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.Equal(t, "detached", resp.Action)
 	})
-	require.NoError(t, err)
-	assert.True(t, resp.Success)
-	assert.Equal(t, "detached", resp.Action)
+
+	t.Run("dry-run does not detach file list ref", func(t *testing.T) {
+		// Re-attach to set up the row, then dry-run remove and confirm it stays
+		_, err := captureJSON(t, func() error {
+			return runRefAddFileList("my-tools", "acme/test-repo-1", "ai-files", true)
+		})
+		require.NoError(t, err)
+
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.TargetFileListRef{}).Count(&before).Error)
+
+		resp, err := captureJSON(t, func() error {
+			return runRefRemoveFileList("my-tools", "acme/test-repo-1", "ai-files", true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+		assert.Equal(t, "detached", resp.Action)
+
+		var after int64
+		require.NoError(t, database.DB().Model(&db.TargetFileListRef{}).Count(&after).Error)
+		assert.Equal(t, before, after)
+	})
 }
 
 func TestRefAddDirList(t *testing.T) {
@@ -859,18 +920,79 @@ func TestRefAddDirList(t *testing.T) {
 		assert.True(t, resp.Success)
 		assert.Equal(t, "already_attached", resp.Action)
 	})
+
+	t.Run("dry-run does not attach dir list ref", func(t *testing.T) {
+		// Create a fresh target with no existing refs so we hit the writer path,
+		// not the idempotent "already_attached" branch.
+		_, err := captureJSON(t, func() error {
+			return runTargetAdd("my-tools", "acme/ref-dl-dry-target", "main", true)
+		})
+		require.NoError(t, err)
+
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.TargetDirectoryListRef{}).Count(&before).Error)
+
+		resp, err := captureJSON(t, func() error {
+			return runRefAddDirList("my-tools", "acme/ref-dl-dry-target", "github-workflows", true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+		assert.Equal(t, "attached", resp.Action)
+
+		var after int64
+		require.NoError(t, database.DB().Model(&db.TargetDirectoryListRef{}).Count(&after).Error)
+		assert.Equal(t, before, after)
+	})
 }
 
 func TestRefRemoveDirList(t *testing.T) {
 	cleanup := setupTestDB(t)
 	defer cleanup()
 
-	resp, err := captureJSON(t, func() error {
-		return runRefRemoveDirList("my-tools", "acme/test-repo-2", "github-workflows", true)
+	t.Run("remove existing ref", func(t *testing.T) {
+		resp, err := captureJSON(t, func() error {
+			return runRefRemoveDirList("my-tools", "acme/test-repo-2", "github-workflows", true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.Equal(t, "detached", resp.Action)
 	})
-	require.NoError(t, err)
-	assert.True(t, resp.Success)
-	assert.Equal(t, "detached", resp.Action)
+
+	t.Run("dry-run does not detach dir list ref", func(t *testing.T) {
+		// Re-attach to set up the row, then dry-run remove and confirm it stays
+		_, err := captureJSON(t, func() error {
+			return runRefAddDirList("my-tools", "acme/test-repo-2", "github-workflows", true)
+		})
+		require.NoError(t, err)
+
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.TargetDirectoryListRef{}).Count(&before).Error)
+
+		resp, err := captureJSON(t, func() error {
+			return runRefRemoveDirList("my-tools", "acme/test-repo-2", "github-workflows", true)
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+		assert.Equal(t, "detached", resp.Action)
+
+		var after int64
+		require.NoError(t, database.DB().Model(&db.TargetDirectoryListRef{}).Count(&after).Error)
+		assert.Equal(t, before, after)
+	})
 }
 
 // ====================

--- a/internal/cli/db_dir_crud.go
+++ b/internal/cli/db_dir_crud.go
@@ -108,6 +108,21 @@ func runDirAdd(groupExternalID, repoFullName, src, dest, exclude, includeOnly st
 		Position:          len(existing),
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "directory_mapping",
+			Data: dirMappingResult{
+				Src:               src,
+				Dest:              dest,
+				Exclude:           []string(mapping.Exclude),
+				IncludeOnly:       []string(mapping.IncludeOnly),
+				PreserveStructure: &preserveStructure,
+				Delete:            deleteFlag,
+			},
+		}, fmt.Sprintf("create directory mapping %q on target %q in group %q", dest, repoFullName, groupExternalID), jsonOutput)
+	}
+
 	if err = dmRepo.Create(ctx, mapping); err != nil {
 		return printErrorResponse("directory_mapping", "created", err.Error(), "", jsonOutput)
 	}
@@ -180,6 +195,17 @@ func runDirRemove(groupExternalID, repoFullName, dest string, jsonOutput bool) e
 			fmt.Sprintf("directory mapping with dest %q not found on target %q", dest, repoFullName),
 			fmt.Sprintf("run 'go-broadcast db dir list --group %s --repo %s --json'", groupExternalID, repoFullName),
 			jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "deleted",
+			Type:   "directory_mapping",
+			Data: map[string]string{
+				"repo": repoFullName,
+				"dest": dest,
+			},
+		}, fmt.Sprintf("delete directory mapping %q from target %q in group %q", dest, repoFullName, groupExternalID), jsonOutput)
 	}
 
 	if err = dmRepo.Delete(ctx, mapping.ID, true); err != nil {

--- a/internal/cli/db_dir_list_crud.go
+++ b/internal/cli/db_dir_list_crud.go
@@ -244,6 +244,19 @@ func runDirListCreate(id, name, description string, jsonOutput bool) error {
 		Position:    len(existingLists),
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "directory_list",
+			Data: dirListResult{
+				ExternalID:  id,
+				Name:        name,
+				Description: description,
+				DirCount:    0,
+			},
+		}, fmt.Sprintf("create directory list %q", id), jsonOutput)
+	}
+
 	if err = dlRepo.Create(ctx, dl); err != nil {
 		return printErrorResponse("directory_list", "created", err.Error(), "", jsonOutput)
 	}
@@ -295,6 +308,14 @@ func runDirListDelete(externalID string, hard, jsonOutput bool) error {
 	if err != nil {
 		return printErrorResponse("directory_list", "deleted", err.Error(),
 			"run 'go-broadcast db dir-list list --json' to see available directory lists", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: deleteAction(hard),
+			Type:   "directory_list",
+			Data:   map[string]string{"external_id": externalID},
+		}, fmt.Sprintf("%s directory list %q", dryRunDeleteVerb(hard), externalID), jsonOutput)
 	}
 
 	dlRepo := db.NewDirectoryListRepository(gormDB)
@@ -385,10 +406,6 @@ func runDirListAddDir(externalID, src, dest, exclude, includeOnly string, preser
 		Position:          len(existing),
 	}
 
-	if err = dmRepo.Create(ctx, mapping); err != nil {
-		return printErrorResponse("directory_mapping", "created", err.Error(), "", jsonOutput)
-	}
-
 	result := dirMappingResult{
 		Src:               src,
 		Dest:              dest,
@@ -396,6 +413,18 @@ func runDirListAddDir(externalID, src, dest, exclude, includeOnly string, preser
 		IncludeOnly:       []string(mapping.IncludeOnly),
 		PreserveStructure: &preserveStructure,
 		Delete:            deleteFlag,
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "directory_mapping",
+			Data:   result,
+		}, fmt.Sprintf("create directory mapping %q in directory list %q", dest, externalID), jsonOutput)
+	}
+
+	if err = dmRepo.Create(ctx, mapping); err != nil {
+		return printErrorResponse("directory_mapping", "created", err.Error(), "", jsonOutput)
 	}
 
 	return printResponse(CLIResponse{
@@ -448,6 +477,17 @@ func runDirListRemoveDir(externalID, dest string, jsonOutput bool) error {
 			fmt.Sprintf("directory mapping with dest %q not found in directory list %q", dest, externalID),
 			fmt.Sprintf("run 'go-broadcast db dir-list get %s --json' to see available mappings", externalID),
 			jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "deleted",
+			Type:   "directory_mapping",
+			Data: map[string]string{
+				"directory_list": externalID,
+				"dest":           dest,
+			},
+		}, fmt.Sprintf("delete directory mapping %q from directory list %q", dest, externalID), jsonOutput)
 	}
 
 	if err = dmRepo.Delete(ctx, mapping.ID, true); err != nil {

--- a/internal/cli/db_file_crud.go
+++ b/internal/cli/db_file_crud.go
@@ -100,6 +100,18 @@ func runFileAdd(groupExternalID, repoFullName, src, dest string, deleteFlag, jso
 		Position:   len(existing),
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "file_mapping",
+			Data: fileMappingResult{
+				Src:    src,
+				Dest:   dest,
+				Delete: deleteFlag,
+			},
+		}, fmt.Sprintf("create file mapping %q on target %q in group %q", dest, repoFullName, groupExternalID), jsonOutput)
+	}
+
 	if err = fmRepo.Create(ctx, mapping); err != nil {
 		return printErrorResponse("file_mapping", "created", err.Error(), "", jsonOutput)
 	}
@@ -169,6 +181,17 @@ func runFileRemove(groupExternalID, repoFullName, dest string, jsonOutput bool) 
 			fmt.Sprintf("file mapping with dest %q not found on target %q", dest, repoFullName),
 			fmt.Sprintf("run 'go-broadcast db file list --group %s --repo %s --json'", groupExternalID, repoFullName),
 			jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "deleted",
+			Type:   "file_mapping",
+			Data: map[string]string{
+				"repo": repoFullName,
+				"dest": dest,
+			},
+		}, fmt.Sprintf("delete file mapping %q from target %q in group %q", dest, repoFullName, groupExternalID), jsonOutput)
 	}
 
 	if err = fmRepo.Delete(ctx, mapping.ID, true); err != nil {

--- a/internal/cli/db_file_list_crud.go
+++ b/internal/cli/db_file_list_crud.go
@@ -244,6 +244,19 @@ func runFileListCreate(id, name, description string, jsonOutput bool) error {
 		Position:    len(existingLists),
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "file_list",
+			Data: fileListResult{
+				ExternalID:  id,
+				Name:        name,
+				Description: description,
+				FileCount:   0,
+			},
+		}, fmt.Sprintf("create file list %q", id), jsonOutput)
+	}
+
 	if err = flRepo.Create(ctx, fl); err != nil {
 		return printErrorResponse("file_list", "created", err.Error(), "", jsonOutput)
 	}
@@ -295,6 +308,14 @@ func runFileListDelete(externalID string, hard, jsonOutput bool) error {
 	if err != nil {
 		return printErrorResponse("file_list", "deleted", err.Error(),
 			"run 'go-broadcast db file-list list --json' to see available file lists", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: deleteAction(hard),
+			Type:   "file_list",
+			Data:   map[string]string{"external_id": externalID},
+		}, fmt.Sprintf("%s file list %q", dryRunDeleteVerb(hard), externalID), jsonOutput)
 	}
 
 	flRepo := db.NewFileListRepository(gormDB)
@@ -378,14 +399,22 @@ func runFileListAddFile(externalID, src, dest string, deleteFlag, jsonOutput boo
 		Position:   len(existing),
 	}
 
-	if err = fmRepo.Create(ctx, mapping); err != nil {
-		return printErrorResponse("file_mapping", "created", err.Error(), "", jsonOutput)
-	}
-
 	result := fileMappingResult{
 		Src:    src,
 		Dest:   dest,
 		Delete: deleteFlag,
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "file_mapping",
+			Data:   result,
+		}, fmt.Sprintf("create file mapping %q in file list %q", dest, externalID), jsonOutput)
+	}
+
+	if err = fmRepo.Create(ctx, mapping); err != nil {
+		return printErrorResponse("file_mapping", "created", err.Error(), "", jsonOutput)
 	}
 
 	return printResponse(CLIResponse{
@@ -438,6 +467,17 @@ func runFileListRemoveFile(externalID, dest string, jsonOutput bool) error {
 			fmt.Sprintf("file mapping with dest %q not found in file list %q", dest, externalID),
 			fmt.Sprintf("run 'go-broadcast db file-list get %s --json' to see available mappings", externalID),
 			jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "deleted",
+			Type:   "file_mapping",
+			Data: map[string]string{
+				"file_list": externalID,
+				"dest":      dest,
+			},
+		}, fmt.Sprintf("delete file mapping %q from file list %q", dest, externalID), jsonOutput)
 	}
 
 	if err = fmRepo.Delete(ctx, mapping.ID, true); err != nil {

--- a/internal/cli/db_group_crud.go
+++ b/internal/cli/db_group_crud.go
@@ -365,6 +365,21 @@ func runGroupCreate(id, name, sourceRepo, sourceBranch, description string, prio
 
 	enabled := !disabled
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "group",
+			Data: groupListResult{
+				ExternalID:  id,
+				Name:        name,
+				Description: description,
+				Priority:    priority,
+				Enabled:     enabled,
+				TargetCount: 0,
+			},
+		}, fmt.Sprintf("create group %q", id), jsonOutput)
+	}
+
 	// Create group + source + global + default in transaction
 	err = gormDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Create group
@@ -493,17 +508,25 @@ func runGroupUpdate(cmd *cobra.Command, externalID, name, description string, pr
 		group.Enabled = &e
 	}
 
-	groupRepo := db.NewGroupRepository(gormDB)
-	if err = groupRepo.Update(ctx, group); err != nil {
-		return printErrorResponse("group", "updated", err.Error(), "", jsonOutput)
-	}
-
 	result := groupListResult{
 		ExternalID:  group.ExternalID,
 		Name:        group.Name,
 		Description: group.Description,
 		Priority:    group.Priority,
 		Enabled:     group.Enabled == nil || *group.Enabled,
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "updated",
+			Type:   "group",
+			Data:   result,
+		}, fmt.Sprintf("update group %q", externalID), jsonOutput)
+	}
+
+	groupRepo := db.NewGroupRepository(gormDB)
+	if err = groupRepo.Update(ctx, group); err != nil {
+		return printErrorResponse("group", "updated", err.Error(), "", jsonOutput)
 	}
 
 	return printResponse(CLIResponse{
@@ -546,6 +569,14 @@ func runGroupDelete(externalID string, hard, jsonOutput bool) error {
 	if err != nil {
 		return printErrorResponse("group", "deleted", err.Error(),
 			"run 'go-broadcast db group list --json' to see available groups", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: deleteAction(hard),
+			Type:   "group",
+			Data:   map[string]string{"external_id": externalID},
+		}, fmt.Sprintf("%s group %q", dryRunDeleteVerb(hard), externalID), jsonOutput)
 	}
 
 	groupRepo := db.NewGroupRepository(gormDB)
@@ -612,14 +643,25 @@ func runGroupSetEnabled(externalID string, enabled, jsonOutput bool) error {
 
 	group.Enabled = &enabled
 
-	groupRepo := db.NewGroupRepository(gormDB)
-	if err = groupRepo.Update(ctx, group); err != nil {
-		return printErrorResponse("group", "updated", err.Error(), "", jsonOutput)
-	}
-
 	action := "enabled"
 	if !enabled {
 		action = "disabled"
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: action,
+			Type:   "group",
+			Data: map[string]interface{}{
+				"external_id": externalID,
+				"enabled":     enabled,
+			},
+		}, fmt.Sprintf("%s group %q", action, externalID), jsonOutput)
+	}
+
+	groupRepo := db.NewGroupRepository(gormDB)
+	if err = groupRepo.Update(ctx, group); err != nil {
+		return printErrorResponse("group", "updated", err.Error(), "", jsonOutput)
 	}
 
 	return printResponse(CLIResponse{

--- a/internal/cli/db_preset_crud.go
+++ b/internal/cli/db_preset_crud.go
@@ -291,6 +291,18 @@ func runPresetCreate(id, name, description string, jsonOutput bool) error {
 		SquashMergeCommitMessage: dflt.SquashMergeCommitMessage,
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "preset",
+			Data: presetListResult{
+				ExternalID:  id,
+				Name:        name,
+				Description: description,
+			},
+		}, fmt.Sprintf("create preset %q", id), jsonOutput)
+	}
+
 	if err = presetRepo.Create(ctx, preset); err != nil {
 		return printErrorResponse("preset", "created", err.Error(), "", jsonOutput)
 	}
@@ -340,6 +352,14 @@ func runPresetDelete(externalID string, hard, jsonOutput bool) error {
 			"run 'go-broadcast db preset list' to see available presets", jsonOutput)
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: deleteAction(hard),
+			Type:   "preset",
+			Data:   map[string]string{"external_id": externalID},
+		}, fmt.Sprintf("%s preset %q", dryRunDeleteVerb(hard), externalID), jsonOutput)
+	}
+
 	if err = presetRepo.Delete(ctx, preset.ID, hard); err != nil {
 		return printErrorResponse("preset", "deleted", err.Error(), "", jsonOutput)
 	}
@@ -387,6 +407,17 @@ func runPresetAssign(presetExternalID, repoFullName string, jsonOutput bool) err
 		return printErrorResponse("preset", "assigned",
 			fmt.Sprintf("preset %q not found: %v", presetExternalID, err),
 			"run 'go-broadcast db preset list' to see available presets", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "assigned",
+			Type:   "preset",
+			Data: map[string]string{
+				"preset": presetExternalID,
+				"repo":   repoFullName,
+			},
+		}, fmt.Sprintf("assign preset %q to repo %q", presetExternalID, repoFullName), jsonOutput)
 	}
 
 	repoRepo := db.NewRepoRepository(gormDB)
@@ -451,6 +482,15 @@ func runPresetImport(configFile string, jsonOutput bool) error {
 
 	ctx := context.Background()
 	presetRepo := db.NewSettingsPresetRepository(database.DB())
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "imported",
+			Type:   "preset",
+			Data:   map[string]int{"count": len(cfg.SettingsPresets)},
+			Count:  len(cfg.SettingsPresets),
+		}, fmt.Sprintf("import %d preset(s) from %q", len(cfg.SettingsPresets), configFile), jsonOutput)
+	}
 
 	imported := 0
 	for _, cp := range cfg.SettingsPresets {

--- a/internal/cli/db_ref_crud.go
+++ b/internal/cli/db_ref_crud.go
@@ -103,6 +103,17 @@ func runRefAddFileList(groupExternalID, repoFullName, fileListExternalID string,
 		Where("target_id = ?", target.ID).
 		Select("COALESCE(MAX(position), -1)").Scan(&maxPos)
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "attached",
+			Type:   "file_list_ref",
+			Data: map[string]string{
+				"repo":      repoFullName,
+				"file_list": fileListExternalID,
+			},
+		}, fmt.Sprintf("attach file list %q to target %q in group %q", fileListExternalID, repoFullName, groupExternalID), jsonOutput)
+	}
+
 	targetRepo := db.NewTargetRepository(gormDB)
 	if err = targetRepo.AddFileListRef(ctx, target.ID, fl.ID, maxPos+1); err != nil {
 		return printErrorResponse("ref", "attached", err.Error(), "", jsonOutput)
@@ -169,6 +180,17 @@ func runRefRemoveFileList(groupExternalID, repoFullName, fileListExternalID stri
 	if err != nil {
 		return printErrorResponse("ref", "detached", err.Error(),
 			"run 'go-broadcast db file-list list --json' to see available file lists", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "detached",
+			Type:   "file_list_ref",
+			Data: map[string]string{
+				"repo":      repoFullName,
+				"file_list": fileListExternalID,
+			},
+		}, fmt.Sprintf("detach file list %q from target %q in group %q", fileListExternalID, repoFullName, groupExternalID), jsonOutput)
 	}
 
 	targetRepo := db.NewTargetRepository(gormDB)
@@ -261,6 +283,17 @@ func runRefAddDirList(groupExternalID, repoFullName, dirListExternalID string, j
 		Where("target_id = ?", target.ID).
 		Select("COALESCE(MAX(position), -1)").Scan(&maxPos)
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "attached",
+			Type:   "directory_list_ref",
+			Data: map[string]string{
+				"repo":     repoFullName,
+				"dir_list": dirListExternalID,
+			},
+		}, fmt.Sprintf("attach directory list %q to target %q in group %q", dirListExternalID, repoFullName, groupExternalID), jsonOutput)
+	}
+
 	targetRepo := db.NewTargetRepository(gormDB)
 	if err = targetRepo.AddDirectoryListRef(ctx, target.ID, dl.ID, maxPos+1); err != nil {
 		return printErrorResponse("ref", "attached", err.Error(), "", jsonOutput)
@@ -327,6 +360,17 @@ func runRefRemoveDirList(groupExternalID, repoFullName, dirListExternalID string
 	if err != nil {
 		return printErrorResponse("ref", "detached", err.Error(),
 			"run 'go-broadcast db dir-list list --json' to see available directory lists", jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "detached",
+			Type:   "directory_list_ref",
+			Data: map[string]string{
+				"repo":     repoFullName,
+				"dir_list": dirListExternalID,
+			},
+		}, fmt.Sprintf("detach directory list %q from target %q in group %q", dirListExternalID, repoFullName, groupExternalID), jsonOutput)
 	}
 
 	targetRepo := db.NewTargetRepository(gormDB)

--- a/internal/cli/db_response.go
+++ b/internal/cli/db_response.go
@@ -16,8 +16,36 @@ type CLIResponse struct {
 	Type    string      `json:"type"`            // "group", "target", "file_list", "directory_list", etc.
 	Data    interface{} `json:"data"`            // result object or array
 	Count   int         `json:"count,omitempty"` // for lists
+	DryRun  bool        `json:"dry_run,omitempty"`
 	Error   string      `json:"error,omitempty"` // error message on failure
 	Hint    string      `json:"hint,omitempty"`  // actionable suggestion on failure
+}
+
+func printDryRunResponse(resp CLIResponse, preview string, jsonOutput bool) error {
+	output.Warn("DRY-RUN MODE: No changes will be made")
+
+	if jsonOutput {
+		resp.Success = true
+		resp.DryRun = true
+		return printResponse(resp, true)
+	}
+
+	output.Info(fmt.Sprintf("[DRY-RUN] would %s", preview))
+	return nil
+}
+
+func deleteAction(hard bool) string {
+	if hard {
+		return "hard-deleted"
+	}
+	return "soft-deleted"
+}
+
+func dryRunDeleteVerb(hard bool) string {
+	if hard {
+		return "hard-delete"
+	}
+	return "soft-delete"
 }
 
 // printResponse outputs a CLIResponse. When jsonOutput is true, it writes structured JSON

--- a/internal/cli/db_target_crud.go
+++ b/internal/cli/db_target_crud.go
@@ -323,6 +323,19 @@ func runTargetAdd(groupExternalID, repoFullName, branch string, jsonOutput bool)
 		return printErrorResponse("target", "created", err.Error(), "", jsonOutput)
 	}
 
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "created",
+			Type:   "target",
+			Data: targetListResult{
+				Repo:     repoFullName,
+				Branch:   branch,
+				Position: len(existingTargets),
+				GroupID:  groupExternalID,
+			},
+		}, fmt.Sprintf("create target %q in group %q", repoFullName, groupExternalID), jsonOutput)
+	}
+
 	// Resolve repo (auto-creates client/org/repo)
 	repoRepo := db.NewRepoRepository(gormDB)
 	repoRecord, err := repoRepo.FindOrCreateFromFullName(ctx, repoFullName, 0)
@@ -399,6 +412,17 @@ func runTargetRemove(groupExternalID, repoFullName string, hard, jsonOutput bool
 		return printErrorResponse("target", "deleted", err.Error(),
 			fmt.Sprintf("run 'go-broadcast db target list --group %s --json' to see available targets", groupExternalID),
 			jsonOutput)
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: deleteAction(hard),
+			Type:   "target",
+			Data: map[string]string{
+				"repo":     repoFullName,
+				"group_id": groupExternalID,
+			},
+		}, fmt.Sprintf("%s target %q from group %q", dryRunDeleteVerb(hard), repoFullName, groupExternalID), jsonOutput)
 	}
 
 	targetRepo := db.NewTargetRepository(gormDB)
@@ -486,16 +510,24 @@ func runTargetUpdate(cmd *cobra.Command, groupExternalID, repoFullName, branch, 
 		target.PRReviewers = splitCSV(prReviewers)
 	}
 
-	targetRepo := db.NewTargetRepository(gormDB)
-	if err = targetRepo.Update(ctx, target); err != nil {
-		return printErrorResponse("target", "updated", err.Error(), "", jsonOutput)
-	}
-
 	result := targetListResult{
 		Repo:     repoFullName,
 		Branch:   target.Branch,
 		Position: target.Position,
 		GroupID:  groupExternalID,
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "updated",
+			Type:   "target",
+			Data:   result,
+		}, fmt.Sprintf("update target %q in group %q", repoFullName, groupExternalID), jsonOutput)
+	}
+
+	targetRepo := db.NewTargetRepository(gormDB)
+	if err = targetRepo.Update(ctx, target); err != nil {
+		return printErrorResponse("target", "updated", err.Error(), "", jsonOutput)
 	}
 
 	return printResponse(CLIResponse{
@@ -617,29 +649,31 @@ func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branc
 				fmt.Sprintf("invalid repo format %q", toRepo), "", jsonOutput)
 		}
 
-		logger := logrus.StandardLogger()
-		ghClient, ghErr := gh.NewClient(ctx, logger, &logging.LogConfig{})
-		if ghErr != nil {
-			return printErrorResponse("target", "cloned",
-				fmt.Sprintf("GitHub client: %v", ghErr), "", jsonOutput)
-		}
+		if !IsDryRun() {
+			logger := logrus.StandardLogger()
+			ghClient, ghErr := gh.NewClient(ctx, logger, &logging.LogConfig{})
+			if ghErr != nil {
+				return printErrorResponse("target", "cloned",
+					fmt.Sprintf("GitHub client: %v", ghErr), "", jsonOutput)
+			}
 
-		_, scaffoldErr := RunScaffold(ctx, ghClient, ScaffoldOptions{
-			Name:    repoParts[1],
-			Owner:   repoParts[0],
-			Preset:  preset,
-			Topics:  topicList,
-			NoClone: noCloneRepo,
-			NoFiles: noFiles,
-		})
-		if scaffoldErr != nil {
-			return printErrorResponse("target", "cloned",
-				fmt.Sprintf("scaffold failed: %v", scaffoldErr),
-				fmt.Sprintf("partial cleanup: gh repo delete %s --yes", toRepo),
-				jsonOutput)
-		}
+			_, scaffoldErr := RunScaffold(ctx, ghClient, ScaffoldOptions{
+				Name:    repoParts[1],
+				Owner:   repoParts[0],
+				Preset:  preset,
+				Topics:  topicList,
+				NoClone: noCloneRepo,
+				NoFiles: noFiles,
+			})
+			if scaffoldErr != nil {
+				return printErrorResponse("target", "cloned",
+					fmt.Sprintf("scaffold failed: %v", scaffoldErr),
+					fmt.Sprintf("partial cleanup: gh repo delete %s --yes", toRepo),
+					jsonOutput)
+			}
 
-		output.Success(fmt.Sprintf("Repository %s created, now cloning target...", toRepo))
+			output.Success(fmt.Sprintf("Repository %s created, now cloning target...", toRepo))
+		}
 	}
 
 	database, err := openDatabase()
@@ -685,6 +719,25 @@ func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branc
 			fmt.Sprintf("source target %q not found in group %q", fromRepo, groupExternalID),
 			fmt.Sprintf("run 'go-broadcast db target list --group %s --json' to see available targets", groupExternalID),
 			jsonOutput)
+	}
+
+	previewBranch := source.Branch
+	if cmd.Flags().Changed("branch") {
+		previewBranch = branch
+	}
+
+	if IsDryRun() {
+		return printDryRunResponse(CLIResponse{
+			Action: "cloned",
+			Type:   "target",
+			Data: targetListResult{
+				Repo:     toRepo,
+				Branch:   previewBranch,
+				Position: len(targets),
+				GroupID:  groupExternalID,
+			},
+			Hint: fmt.Sprintf("cloned from %s", fromRepo),
+		}, fmt.Sprintf("clone target %q to %q in group %q", fromRepo, toRepo, groupExternalID), jsonOutput)
 	}
 
 	// Execute deep clone in a transaction


### PR DESCRIPTION
## Summary

The global `--dry-run` flag was silently persisting writes for several `go-broadcast db <crud>` commands, breaking the preview contract that callers rely on for safety.

Repro that motivated the fix:
```
go-broadcast db target clone --group <g> --from <a> --to <b> --dry-run
# → "target cloned successfully"   ← actually wrote the row

go-broadcast db target clone --group <g> --from <a> --to <b>
# → ERROR: target already exists
```

## Changes

- Wire `IsDryRun()` guards before every DB write across `internal/cli/db_*_crud.go`:
  - `target` add / remove / update / clone
  - `file` and `dir` add / remove (incl. list variants)
  - `group` create / delete
  - `preset` create / delete
  - `bulk` ops
- Add a shared `printDryRunResponse` helper in `db_response.go` that emits a clear `[DRY-RUN] would <verb> ...` message and short-circuits the writer
- Add regression coverage in `db_crud_test.go` asserting that dry-run invocations leave the underlying tables untouched

## Test plan

- [x] `go test -race ./internal/cli/...` — all tests pass (249s)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go vet ./...` — clean
- [x] New regression test verifies row count unchanged after `--dry-run`
- [ ] Reviewer: spot-check the dry-run path on at least one non-target command (e.g. `db file add --dry-run`)