### PR TITLE
fix(cli): close database validation gaps

### DIFF
--- a/internal/cli/db_validate.go
+++ b/internal/cli/db_validate.go
@@ -28,6 +28,7 @@ Checks performed:
 • Missing file lists (file list refs pointing to deleted lists)
 • Missing directory lists (directory list refs pointing to deleted lists)
 • Circular dependencies between groups
+• Active targets with no file mappings, directory mappings, or list references
 • Orphaned file mappings (mappings with invalid owner references)
 • Orphaned directory mappings (mappings with invalid owner references)
 
@@ -71,9 +72,19 @@ type ValidationCheck struct {
 func runDBValidate(_ *cobra.Command, _ []string) error {
 	path := getDBPath()
 
+	result, err := runDBValidation(path)
+	if err != nil {
+		return err
+	}
+
+	return printValidationResult(result)
+}
+
+// runDBValidation executes database validation checks and returns the result without printing.
+func runDBValidation(path string) (ValidationResult, error) {
 	// Check if database exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fmt.Errorf("database does not exist: %s (run 'go-broadcast db init' to create)", path) //nolint:err113 // user-facing CLI error
+		return ValidationResult{}, fmt.Errorf("database does not exist: %s (run 'go-broadcast db init' to create)", path) //nolint:err113 // user-facing CLI error
 	}
 
 	// Open database
@@ -82,7 +93,7 @@ func runDBValidate(_ *cobra.Command, _ []string) error {
 		LogLevel: logger.Silent,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to open database: %w", err)
+		return ValidationResult{}, fmt.Errorf("failed to open database: %w", err)
 	}
 	defer func() { _ = database.Close() }()
 
@@ -103,9 +114,9 @@ func runDBValidate(_ *cobra.Command, _ []string) error {
 				Type:    "config",
 				Message: "No configuration found in database",
 			})
-			return printValidationResult(result)
+			return result, nil
 		}
-		return fmt.Errorf("failed to load config: %w", err)
+		return ValidationResult{}, fmt.Errorf("failed to load config: %w", err)
 	}
 
 	// Run all validation checks
@@ -114,12 +125,13 @@ func runDBValidate(_ *cobra.Command, _ []string) error {
 	checkOrphanedFileMappings(ctx, gormDB, &result)
 	checkOrphanedDirectoryMappings(ctx, gormDB, &result)
 	checkCircularDependencies(ctx, gormDB, config.ID, &result)
+	checkEmptyActiveTargets(ctx, gormDB, config.ID, &result)
 
 	if len(result.Errors) > 0 {
 		result.Valid = false
 	}
 
-	return printValidationResult(result)
+	return result, nil
 }
 
 // checkOrphanedFileListRefs checks for target_file_list_refs pointing to non-existent file lists
@@ -381,6 +393,69 @@ func checkCircularDependencies(ctx context.Context, gormDB *gorm.DB, configID ui
 		Type:    "dependencies",
 		Message: fmt.Sprintf("No circular dependencies (checked %d groups, %d dependencies)", groupCount, depCount),
 		Count:   int(depCount),
+	})
+}
+
+// checkEmptyActiveTargets checks for active targets with no mappings or list references.
+func checkEmptyActiveTargets(ctx context.Context, gormDB *gorm.DB, configID uint, result *ValidationResult) {
+	type EmptyTarget struct {
+		TargetID        uint
+		GroupExternalID string
+		OrgName         string
+		RepoName        string
+	}
+
+	var emptyTargets []EmptyTarget
+	err := gormDB.WithContext(ctx).
+		Table("targets").
+		Select(`
+			targets.id AS target_id,
+			groups.external_id AS group_external_id,
+			organizations.name AS org_name,
+			repos.name AS repo_name`).
+		Joins("JOIN groups ON groups.id = targets.group_id").
+		Joins("JOIN repos ON repos.id = targets.repo_id").
+		Joins("JOIN organizations ON organizations.id = repos.organization_id").
+		Where("targets.deleted_at IS NULL").
+		Where("groups.config_id = ?", configID).
+		Where(`
+			(SELECT COUNT(*) FROM file_mappings
+				WHERE file_mappings.owner_type = 'target'
+				  AND file_mappings.owner_id = targets.id
+				  AND file_mappings.deleted_at IS NULL) = 0
+			AND (SELECT COUNT(*) FROM directory_mappings
+				WHERE directory_mappings.owner_type = 'target'
+				  AND directory_mappings.owner_id = targets.id
+				  AND directory_mappings.deleted_at IS NULL) = 0
+			AND (SELECT COUNT(*) FROM target_file_list_refs
+				WHERE target_file_list_refs.target_id = targets.id) = 0
+			AND (SELECT COUNT(*) FROM target_directory_list_refs
+				WHERE target_directory_list_refs.target_id = targets.id) = 0`).
+		Scan(&emptyTargets).Error
+	if err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Type:    "empty_targets_check",
+			Message: "Failed to check empty active targets",
+			Details: err.Error(),
+		})
+		return
+	}
+
+	if len(emptyTargets) > 0 {
+		for _, target := range emptyTargets {
+			identifier := fmt.Sprintf("%s / %s/%s", target.GroupExternalID, target.OrgName, target.RepoName)
+			result.Errors = append(result.Errors, ValidationError{
+				Type:    "empty_target",
+				Message: fmt.Sprintf("Active target '%s' has no file mappings, directory mappings, or list references", identifier),
+				Details: fmt.Sprintf("target_id=%d", target.TargetID),
+			})
+		}
+		return
+	}
+
+	result.Checks = append(result.Checks, ValidationCheck{
+		Type:    "empty_targets",
+		Message: "All active targets have mappings or list references",
 	})
 }
 

--- a/internal/cli/db_validate_test.go
+++ b/internal/cli/db_validate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/mrz1836/go-broadcast/internal/db"
 )
@@ -71,6 +72,15 @@ func TestDBValidate(t *testing.T) {
 		Branch:  "main",
 	}
 	require.NoError(t, gormDB.Create(target).Error)
+
+	// non-empty mapping ensures the empty-target check passes; the original test relied on an unguarded zero state.
+	validMapping := &db.FileMapping{
+		OwnerType: "target",
+		OwnerID:   target.ID,
+		Src:       "README.md",
+		Dest:      "README.md",
+	}
+	require.NoError(t, gormDB.Create(validMapping).Error)
 
 	require.NoError(t, database.Close())
 
@@ -480,6 +490,104 @@ func TestDBValidateEmpty(t *testing.T) {
 		assert.True(t, result.Valid)
 		assert.NotEmpty(t, result.Checks)
 	})
+}
+
+// TestDBValidateEmptyTarget tests active targets with and without mappings/list refs.
+func TestDBValidateEmptyTarget(t *testing.T) {
+	testCases := []struct {
+		name         string
+		populate     func(t *testing.T, gormDB *gorm.DB, targetID uint, configID uint)
+		wantValid    bool
+		wantEmptyErr bool
+	}{
+		{
+			name:         "empty target is invalid",
+			wantValid:    false,
+			wantEmptyErr: true,
+		},
+		{
+			name: "file mapping only is valid",
+			populate: func(t *testing.T, gormDB *gorm.DB, targetID uint, _ uint) {
+				require.NoError(t, gormDB.Create(&db.FileMapping{OwnerType: "target", OwnerID: targetID, Src: "README.md", Dest: "README.md"}).Error)
+			},
+			wantValid: true,
+		},
+		{
+			name: "directory mapping only is valid",
+			populate: func(t *testing.T, gormDB *gorm.DB, targetID uint, _ uint) {
+				require.NoError(t, gormDB.Create(&db.DirectoryMapping{OwnerType: "target", OwnerID: targetID, Src: "templates", Dest: "templates"}).Error)
+			},
+			wantValid: true,
+		},
+		{
+			name: "file list ref only is valid",
+			populate: func(t *testing.T, gormDB *gorm.DB, targetID uint, configID uint) {
+				fileList := &db.FileList{ConfigID: configID, ExternalID: "files", Name: "Files"}
+				require.NoError(t, gormDB.Create(fileList).Error)
+				require.NoError(t, gormDB.Create(&db.TargetFileListRef{TargetID: targetID, FileListID: fileList.ID}).Error)
+			},
+			wantValid: true,
+		},
+		{
+			name: "directory list ref only is valid",
+			populate: func(t *testing.T, gormDB *gorm.DB, targetID uint, configID uint) {
+				dirList := &db.DirectoryList{ConfigID: configID, ExternalID: "dirs", Name: "Directories"}
+				require.NoError(t, gormDB.Create(dirList).Error)
+				require.NoError(t, gormDB.Create(&db.TargetDirectoryListRef{TargetID: targetID, DirectoryListID: dirList.ID}).Error)
+			},
+			wantValid: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpPath, targetID, configID := createDBValidateTargetFixture(t)
+			database, err := db.Open(db.OpenOptions{Path: tmpPath})
+			require.NoError(t, err)
+			if tc.populate != nil {
+				tc.populate(t, database.DB(), targetID, configID)
+			}
+			require.NoError(t, database.Close())
+
+			result, err := runDBValidation(tmpPath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValid, result.Valid)
+
+			hasEmptyTarget := false
+			for _, validationErr := range result.Errors {
+				if validationErr.Type == "empty_target" {
+					hasEmptyTarget = true
+					assert.Contains(t, validationErr.Message, "test-group / mrz1836/target-repo")
+				}
+			}
+			assert.Equal(t, tc.wantEmptyErr, hasEmptyTarget)
+		})
+	}
+}
+
+func createDBValidateTargetFixture(t *testing.T) (string, uint, uint) {
+	t.Helper()
+
+	tmpPath := filepath.Join(t.TempDir(), "validate-target.db")
+	database, err := db.Open(db.OpenOptions{Path: tmpPath, AutoMigrate: true})
+	require.NoError(t, err)
+	gormDB := database.DB()
+
+	cfg := &db.Config{ExternalID: "test-config", Name: "Test Config", Version: 1}
+	require.NoError(t, gormDB.Create(cfg).Error)
+	client := &db.Client{Name: "test-client"}
+	require.NoError(t, gormDB.Create(client).Error)
+	org := &db.Organization{ClientID: client.ID, Name: "mrz1836"}
+	require.NoError(t, gormDB.Create(org).Error)
+	repo := &db.Repo{OrganizationID: org.ID, Name: "target-repo"}
+	require.NoError(t, gormDB.Create(repo).Error)
+	group := &db.Group{ConfigID: cfg.ID, ExternalID: "test-group", Name: "Test Group"}
+	require.NoError(t, gormDB.Create(group).Error)
+	target := &db.Target{GroupID: group.ID, RepoID: repo.ID, Branch: "main"}
+	require.NoError(t, gormDB.Create(target).Error)
+	require.NoError(t, database.Close())
+
+	return tmpPath, target.ID, cfg.ID
 }
 
 // Benchmarks moved to db_query_benchmark_test.go (bench_heavy tag)

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -72,6 +72,10 @@ func runValidate(cmd *cobra.Command, _ []string) error {
 }
 
 func runValidateWithFlags(flags *Flags, cmd *cobra.Command) error {
+	if flags.FromDB {
+		return runValidateFromDB(flags, cmd)
+	}
+
 	log := logrus.WithField("command", "validate")
 	configPath := flags.ConfigFile
 
@@ -103,6 +107,48 @@ func runValidateWithFlags(flags *Flags, cmd *cobra.Command) error {
 		return fmt.Errorf("configuration validation failed: %w", err)
 	}
 
+	displayConfigValidationSummary(cfg)
+	runAdditionalValidationChecks(cfg)
+	runRemoteValidationChecks(flags, cmd, cfg)
+
+	return nil
+}
+
+func runValidateFromDB(flags *Flags, cmd *cobra.Command) error {
+	configPath := flags.ConfigFile
+	if configPath != "" && configPath != "sync.yaml" {
+		return fmt.Errorf("--from-db cannot be used with --config %q; remove one of these flags", configPath) //nolint:err113 // user-facing CLI error
+	}
+
+	output.Info("Validating configuration from database")
+	output.Info("")
+	output.Info("Configuration validation")
+	output.Info("========================")
+
+	cfg, err := loadConfigFromDB()
+	if err != nil {
+		output.Error(fmt.Sprintf("Database configuration validation failed: %v", err))
+		return err
+	}
+
+	displayConfigValidationSummary(cfg)
+	if !runAdditionalValidationChecks(cfg) {
+		return fmt.Errorf("configuration validation failed") //nolint:err113 // user-facing CLI error
+	}
+	runRemoteValidationChecks(flags, cmd, cfg)
+
+	output.Info("")
+	output.Info("Database integrity")
+	output.Info("==================")
+
+	result, err := runDBValidation(getDBPath())
+	if err != nil {
+		return err
+	}
+	return printValidationResult(result)
+}
+
+func displayConfigValidationSummary(cfg *config.Config) {
 	// Display configuration summary
 	output.Success("✓ Configuration is valid!")
 	output.Info("")
@@ -112,7 +158,7 @@ func runValidateWithFlags(flags *Flags, cmd *cobra.Command) error {
 	groups := cfg.Groups
 	if len(groups) == 0 {
 		output.Info("  No configuration groups found")
-		return nil
+		return
 	}
 
 	// Display group-based configuration (guaranteed non-empty from check above)
@@ -121,30 +167,31 @@ func runValidateWithFlags(flags *Flags, cmd *cobra.Command) error {
 	// Show target details
 	totalFiles := 0
 
-	if len(groups) > 0 {
-		group := groups[0]
-		for i, target := range group.Targets {
-			output.Info(fmt.Sprintf("    %d. %s", i+1, target.Repo))
-			output.Info(fmt.Sprintf("       Files: %d mappings", len(target.Files)))
+	group := groups[0]
+	for i, target := range group.Targets {
+		output.Info(fmt.Sprintf("    %d. %s", i+1, target.Repo))
+		output.Info(fmt.Sprintf("       Files: %d mappings", len(target.Files)))
 
-			// Count transforms
-			transformCount := 0
-			if target.Transform.RepoName {
-				transformCount++
-			}
-
-			transformCount += len(target.Transform.Variables)
-			if transformCount > 0 {
-				output.Info(fmt.Sprintf("       Transforms: %d configured", transformCount))
-			}
-
-			totalFiles += len(target.Files)
+		// Count transforms
+		transformCount := 0
+		if target.Transform.RepoName {
+			transformCount++
 		}
+
+		transformCount += len(target.Transform.Variables)
+		if transformCount > 0 {
+			output.Info(fmt.Sprintf("       Transforms: %d configured", transformCount))
+		}
+
+		totalFiles += len(target.Files)
 	}
 
 	output.Info("")
 	output.Info(fmt.Sprintf("Total file mappings: %d", totalFiles))
+}
 
+func runAdditionalValidationChecks(cfg *config.Config) bool {
+	groups := cfg.Groups
 	// Additional validation checks — run lightweight per-check validation and report individually
 	output.Info("")
 	output.Info("Additional checks:")
@@ -190,6 +237,10 @@ func runValidateWithFlags(flags *Flags, cmd *cobra.Command) error {
 		output.Success("  ✓ No duplicate file destinations")
 	}
 
+	return allPassed
+}
+
+func runRemoteValidationChecks(flags *Flags, cmd *cobra.Command, cfg *config.Config) {
 	// Get command flags
 	skipRemoteChecks, _ := cmd.Flags().GetBool("skip-remote-checks")
 	sourceOnly, _ := cmd.Flags().GetBool("source-only")
@@ -218,8 +269,6 @@ func runValidateWithFlags(flags *Flags, cmd *cobra.Command) error {
 		output.Info("  ⚠ Repository accessibility check skipped")
 		output.Info("  ⚠ Source file existence check skipped")
 	}
-
-	return nil
 }
 
 // validateRepositoryAccessibility checks if source and target repositories are accessible via GitHub API

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mrz1836/go-broadcast/internal/config"
+	"github.com/mrz1836/go-broadcast/internal/db"
 	"github.com/mrz1836/go-broadcast/internal/logging"
 	"github.com/mrz1836/go-broadcast/internal/output"
 	"github.com/mrz1836/go-broadcast/internal/testutil"
@@ -316,6 +317,93 @@ groups:
 			}
 		})
 	}
+}
+
+// TestRunValidateFromDB verifies validate --from-db routes to database-backed config and DB integrity checks.
+func TestRunValidateFromDB(t *testing.T) {
+	tmpPath := createValidateFromDBFixture(t)
+
+	oldDBPath := dbPath
+	oldFlags := GetGlobalFlags()
+	defer func() {
+		dbPath = oldDBPath
+		SetFlags(oldFlags)
+	}()
+	dbPath = tmpPath
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("skip-remote-checks", false, "")
+	cmd.Flags().Bool("source-only", false, "")
+	require.NoError(t, cmd.Flags().Set("skip-remote-checks", "true"))
+
+	flags := &Flags{ConfigFile: "sync.yaml", FromDB: true, LogLevel: oldFlags.LogLevel}
+	SetFlags(flags)
+
+	scope := output.CaptureOutput()
+	err := runValidateWithFlags(flags, cmd)
+	scope.Restore()
+
+	require.NoError(t, err)
+	capturedOutput := scope.Stdout.String() + scope.Stderr.String()
+	assert.Contains(t, capturedOutput, "Configuration validation")
+	assert.Contains(t, capturedOutput, "Database integrity")
+	assert.Contains(t, capturedOutput, "✓ Database is valid!")
+}
+
+func TestRunValidateFromDBConfigConflict(t *testing.T) {
+	oldFlags := GetGlobalFlags()
+	defer SetFlags(oldFlags)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("skip-remote-checks", false, "")
+	cmd.Flags().Bool("source-only", false, "")
+
+	flags := &Flags{ConfigFile: "foo.yaml", FromDB: true, LogLevel: oldFlags.LogLevel}
+	SetFlags(flags)
+
+	err := runValidateWithFlags(flags, cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--from-db")
+	assert.Contains(t, err.Error(), "--config")
+	assert.Contains(t, err.Error(), "foo.yaml")
+}
+
+func createValidateFromDBFixture(t *testing.T) string {
+	t.Helper()
+
+	tmpPath := filepath.Join(t.TempDir(), "validate-from-db.db")
+	database, err := db.Open(db.OpenOptions{Path: tmpPath, AutoMigrate: true})
+	require.NoError(t, err)
+	converter := db.NewConverter(database.DB())
+
+	cfg := &config.Config{
+		Version: 1,
+		ID:      "test-config",
+		Name:    "Test Config",
+		Groups: []config.Group{
+			{
+				ID:   "test-group",
+				Name: "Test Group",
+				Source: config.SourceConfig{
+					Repo:   "mrz1836/source-repo",
+					Branch: "main",
+				},
+				Targets: []config.TargetConfig{
+					{
+						Repo: "mrz1836/target-repo",
+						Files: []config.FileMapping{
+							{Src: "README.md", Dest: "README.md"},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err = converter.ImportConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
+
+	return tmpPath
 }
 
 // TestValidateOutputFormatting tests the output formatting


### PR DESCRIPTION
## Summary
- flag active database targets that have no direct mappings and no list references
- make `validate --from-db` load database-backed configuration instead of `sync.yaml`
- run database integrity checks after DB-backed configuration validation with separate output sections

## Validation
- `go test ./internal/cli ./internal/db ./internal/config`
- `golangci-lint run ./internal/cli/... ./internal/db/... ./internal/config/...`
- manual smoke: `db import`, `db validate`, and `validate --from-db --skip-remote-checks` against a temporary database

## Notes
- `magex test` currently fails outside this change in `internal/testutil` permission expectations on `TestCreateTestDirectory/CreateNewDirectory` (`expected 0x1e8`, `actual 0x1c0`).
