### PR TITLE
fix(cli): resolve file_list_refs and directory_list_refs under --from-db

### DIFF
--- a/internal/cli/db_diff.go
+++ b/internal/cli/db_diff.go
@@ -107,6 +107,10 @@ func runDBDiff(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to export database: %w", err)
 	}
 
+	if err := config.ApplyDefaultsAndResolve(dbCfg); err != nil {
+		return fmt.Errorf("failed to apply defaults and resolve list references on DB side: %w", err)
+	}
+
 	// Compare configurations
 	output.Info("\nComparing configurations...")
 	diffs := compareConfigs(yamlCfg, dbCfg, dbDiffDetail)

--- a/internal/cli/db_diff_resolve_test.go
+++ b/internal/cli/db_diff_resolve_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm/logger"
+
+	"github.com/mrz1836/go-broadcast/internal/config"
+	"github.com/mrz1836/go-broadcast/internal/db"
+)
+
+// TestDBDiff_ResolvesListRefs_OnDBSide verifies that the db_diff code path resolves
+// file_list_refs on the DB-exported config before comparing, producing symmetric
+// inputs for compareConfigs (AC-12).
+//
+// Case 1: identical YAML and DB state → zero diffs after both sides are resolved.
+// Case 2: DB missing a file_list that YAML has → compareConfigs detects the gap.
+func TestDBDiff_ResolvesListRefs_OnDBSide(t *testing.T) {
+	tmpDir := t.TempDir()
+	testDBPath := filepath.Join(tmpDir, "diff-resolve.db")
+
+	database, err := db.Open(db.OpenOptions{
+		Path:        testDBPath,
+		LogLevel:    logger.Silent,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	ctx := context.Background()
+	converter := db.NewConverter(database.DB())
+
+	// Seed DB with a config carrying file_list "fl1" and a target with file_list_refs: ["fl1"].
+	seedCfg := &config.Config{
+		Version: 1,
+		Name:    "diff-test",
+		ID:      "diff-test",
+		FileLists: []config.FileList{
+			{
+				ID:   "fl1",
+				Name: "File List 1",
+				Files: []config.FileMapping{
+					{Src: "shared.txt", Dest: "shared.txt"},
+				},
+			},
+		},
+		Groups: []config.Group{
+			{
+				Name: "Test Group",
+				ID:   "diff-group",
+				Source: config.SourceConfig{
+					Repo:   "acme/source",
+					Branch: "main",
+				},
+				Targets: []config.TargetConfig{
+					{
+						Repo:         "acme/target1",
+						FileListRefs: []string{"fl1"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = converter.ImportConfig(ctx, seedCfg)
+	require.NoError(t, err)
+
+	t.Run("zero diffs when YAML and DB carry matching file_list_refs", func(t *testing.T) {
+		// Simulate the YAML side: apply defaults + resolve (what config.Load does).
+		yamlCfg := &config.Config{
+			Version: 1,
+			Name:    "diff-test",
+			ID:      "diff-test",
+			FileLists: []config.FileList{
+				{
+					ID:   "fl1",
+					Name: "File List 1",
+					Files: []config.FileMapping{
+						{Src: "shared.txt", Dest: "shared.txt"},
+					},
+				},
+			},
+			Groups: []config.Group{
+				{
+					Name: "Test Group",
+					ID:   "diff-group",
+					Source: config.SourceConfig{
+						Repo:   "acme/source",
+						Branch: "main",
+					},
+					Targets: []config.TargetConfig{
+						{
+							Repo:         "acme/target1",
+							FileListRefs: []string{"fl1"},
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, config.ApplyDefaultsAndResolve(yamlCfg))
+
+		// Simulate the DB side: export then resolve (what db_diff.go now does after Phase 1 fix).
+		dbCfg, dbErr := converter.ExportConfig(ctx, "diff-test")
+		require.NoError(t, dbErr)
+
+		// Before resolve the target should have FileListRefs but empty Files.
+		require.NotEmpty(t, dbCfg.Groups[0].Targets[0].FileListRefs,
+			"exported config must carry file_list_refs before resolve")
+		assert.Empty(t, dbCfg.Groups[0].Targets[0].Files,
+			"exported config must NOT have Files before ApplyDefaultsAndResolve is called")
+
+		require.NoError(t, config.ApplyDefaultsAndResolve(dbCfg))
+
+		// After resolve the target must have files merged from fl1.
+		assert.NotEmpty(t, dbCfg.Groups[0].Targets[0].Files,
+			"target.Files must be non-empty after ApplyDefaultsAndResolve resolves the file_list_ref")
+
+		// Structural comparison should show no diffs when both sides are resolved.
+		diffs := compareConfigs(yamlCfg, dbCfg, false)
+		assert.Empty(t, diffs, "expected zero compareConfigs diffs when YAML and DB carry matching resolved config")
+	})
+
+	t.Run("non-empty diffs when YAML has a file_list that DB is missing", func(t *testing.T) {
+		// YAML declares an extra file_list "fl2" that is absent from the DB.
+		// compareConfigs should detect the missing FileList on the DB side.
+		yamlWithExtra := &config.Config{
+			Version: 1,
+			Name:    "diff-test",
+			ID:      "diff-test",
+			FileLists: []config.FileList{
+				{
+					ID:   "fl1",
+					Name: "File List 1",
+					Files: []config.FileMapping{
+						{Src: "shared.txt", Dest: "shared.txt"},
+					},
+				},
+				{
+					ID:   "fl2",
+					Name: "File List 2",
+					Files: []config.FileMapping{
+						{Src: "extra.txt", Dest: "extra.txt"},
+					},
+				},
+			},
+			Groups: []config.Group{
+				{
+					Name: "Test Group",
+					ID:   "diff-group",
+					Source: config.SourceConfig{
+						Repo:   "acme/source",
+						Branch: "main",
+					},
+					Targets: []config.TargetConfig{
+						{
+							Repo:         "acme/target1",
+							FileListRefs: []string{"fl1"},
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, config.ApplyDefaultsAndResolve(yamlWithExtra))
+
+		dbCfg, dbErr := converter.ExportConfig(ctx, "diff-test")
+		require.NoError(t, dbErr)
+		require.NoError(t, config.ApplyDefaultsAndResolve(dbCfg))
+
+		diffs := compareConfigs(yamlWithExtra, dbCfg, false)
+		assert.NotEmpty(t, diffs,
+			"expected non-empty compareConfigs diffs when YAML has a file_list absent from DB")
+
+		// Verify the diff mentions the missing file_list specifically.
+		diffStr := ""
+		for _, d := range diffs {
+			diffStr += d
+		}
+		assert.Contains(t, diffStr, "FileList",
+			"diff output should reference the missing FileList")
+	})
+}

--- a/internal/cli/db_export_roundtrip_test.go
+++ b/internal/cli/db_export_roundtrip_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"gorm.io/gorm/logger"
+
+	"github.com/mrz1836/go-broadcast/internal/config"
+	"github.com/mrz1836/go-broadcast/internal/db"
+)
+
+// TestDBExport_PreservesListRefs_Unresolved locks in the deliberate exception (call-site
+// audit row #8): the db_export.go path calls converter.ExportConfig WITHOUT subsequently
+// calling config.ApplyDefaultsAndResolve, so the exported YAML preserves file_list_refs
+// and directory_list_refs as symbolic references rather than inlining the list entries.
+// This protects the import→export round-trip authoring shape (AC-13).
+func TestDBExport_PreservesListRefs_Unresolved(t *testing.T) {
+	tmpDir := t.TempDir()
+	testDBPath := filepath.Join(tmpDir, "export-roundtrip.db")
+
+	database, err := db.Open(db.OpenOptions{
+		Path:        testDBPath,
+		LogLevel:    logger.Silent,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	ctx := context.Background()
+	converter := db.NewConverter(database.DB())
+
+	// Seed: a config with one file_list "fl1" and one directory_list "dl1".
+	// The single target references both via file_list_refs and directory_list_refs only —
+	// it carries NO inline file or directory mappings.
+	seedCfg := &config.Config{
+		Version: 1,
+		Name:    "roundtrip-test",
+		ID:      "roundtrip-cfg",
+		FileLists: []config.FileList{
+			{
+				ID:   "fl1",
+				Name: "File List 1",
+				Files: []config.FileMapping{
+					{Src: "ref-file.txt", Dest: "ref-file.txt"},
+				},
+			},
+		},
+		DirectoryLists: []config.DirectoryList{
+			{
+				ID:   "dl1",
+				Name: "Directory List 1",
+				Directories: []config.DirectoryMapping{
+					{Src: ".github/workflows", Dest: ".github/workflows"},
+				},
+			},
+		},
+		Groups: []config.Group{
+			{
+				Name: "Test Group",
+				ID:   "roundtrip-group",
+				Source: config.SourceConfig{
+					Repo:   "acme/source",
+					Branch: "main",
+				},
+				Targets: []config.TargetConfig{
+					{
+						Repo:              "acme/target1",
+						FileListRefs:      []string{"fl1"},
+						DirectoryListRefs: []string{"dl1"},
+						// Intentionally no inline Files or Directories.
+					},
+				},
+			},
+		},
+	}
+
+	_, err = converter.ImportConfig(ctx, seedCfg)
+	require.NoError(t, err)
+
+	t.Run("file_list_refs preserved un-inlined on export", func(t *testing.T) {
+		// db_export.go calls ExportConfig without ApplyDefaultsAndResolve.
+		exportedCfg, exportErr := converter.ExportConfig(ctx, "roundtrip-cfg")
+		require.NoError(t, exportErr)
+
+		target := exportedCfg.Groups[0].Targets[0]
+
+		// The ref must be preserved as a symbolic reference.
+		assert.Contains(t, target.FileListRefs, "fl1",
+			"exported config must preserve file_list_refs verbatim")
+
+		// The list entries must NOT be inlined into target.Files.
+		for _, f := range target.Files {
+			assert.NotEqual(t, "ref-file.txt", f.Dest,
+				"ref-file.txt must not be inlined into target.files on db export")
+		}
+
+		// Marshal to YAML and verify the same invariant at the text level.
+		yamlData, marshalErr := yaml.Marshal(exportedCfg)
+		require.NoError(t, marshalErr)
+		yamlStr := string(yamlData)
+
+		assert.Contains(t, yamlStr, "fl1",
+			"YAML output must contain file_list_refs entry 'fl1'")
+		// "ref-file.txt" should only appear inside the file_lists section, not inline in targets.
+		// A simple safeguard: the YAML target block should not contain the ref content inline.
+		assert.Contains(t, yamlStr, "file_list_refs",
+			"YAML output must contain file_list_refs key")
+	})
+
+	t.Run("directory_list_refs preserved un-inlined on export", func(t *testing.T) {
+		exportedCfg, exportErr := converter.ExportConfig(ctx, "roundtrip-cfg")
+		require.NoError(t, exportErr)
+
+		target := exportedCfg.Groups[0].Targets[0]
+
+		// The ref must be preserved as a symbolic reference.
+		assert.Contains(t, target.DirectoryListRefs, "dl1",
+			"exported config must preserve directory_list_refs verbatim")
+
+		// The list entries must NOT be inlined into target.Directories.
+		for _, d := range target.Directories {
+			assert.NotEqual(t, ".github/workflows", d.Dest,
+				".github/workflows must not be inlined into target.directories on db export")
+		}
+
+		yamlData, marshalErr := yaml.Marshal(exportedCfg)
+		require.NoError(t, marshalErr)
+		yamlStr := string(yamlData)
+
+		assert.Contains(t, yamlStr, "dl1",
+			"YAML output must contain directory_list_refs entry 'dl1'")
+		assert.Contains(t, yamlStr, "directory_list_refs",
+			"YAML output must contain directory_list_refs key")
+	})
+}

--- a/internal/cli/export_config_callsite_audit_test.go
+++ b/internal/cli/export_config_callsite_audit_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExportConfigCallsiteAudit is a forward-protection static check that enumerates
+// every production caller of converter.ExportConfig in the internal/cli package and
+// asserts that each is in an explicit allowlist (AC-14).
+//
+// The allowlist has three entries, each with a documented classification:
+//
+//	sync.go      — loadConfigFromDB calls ExportConfig and immediately follows with
+//	               config.ApplyDefaultsAndResolve (needs-resolve site).
+//	db_diff.go   — calls ExportConfig then ApplyDefaultsAndResolve so DB and YAML
+//	               sides are both resolved before compareConfigs (needs-resolve site).
+//	db_export.go — deliberate exception: preserves file_list_refs and
+//	               directory_list_refs un-inlined for round-trip authoring
+//	               (must-stay-unresolved; locked in by TestDBExport_PreservesListRefs_Unresolved).
+//
+// A new production caller of ExportConfig will fail this test until it is explicitly
+// added here with its classification, preventing silent regression to the unresolved
+// --from-db behavior that this PR fixes.
+func TestExportConfigCallsiteAudit(t *testing.T) {
+	allowlist := map[string]string{
+		"sync.go":      "needs-resolve: loadConfigFromDB calls ExportConfig + ApplyDefaultsAndResolve",
+		"db_diff.go":   "needs-resolve: db_diff calls ExportConfig + ApplyDefaultsAndResolve",
+		"db_export.go": "must-stay-unresolved: deliberate exception for round-trip authoring shape",
+	}
+
+	// The working directory for tests is the package directory (internal/cli/),
+	// so os.ReadDir(".") enumerates the production source files.
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	callerFiles := map[string]bool{}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		f, parseErr := parser.ParseFile(fset, name, nil, 0)
+		require.NoError(t, parseErr, "failed to parse production file %s", name)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if sel.Sel.Name == "ExportConfig" {
+				callerFiles[name] = true
+			}
+			return true
+		})
+	}
+
+	// Every discovered caller must be in the allowlist.
+	for file := range callerFiles {
+		classification, ok := allowlist[file]
+		assert.True(t, ok,
+			"unexpected production caller of converter.ExportConfig in %s — "+
+				"add it to the allowlist in TestExportConfigCallsiteAudit with an explicit "+
+				"classification (needs-resolve or must-stay-unresolved)", file)
+		if ok {
+			assert.NotEmpty(t, classification)
+		}
+	}
+
+	// Every allowlist entry must actually exist as a caller (guards against stale entries).
+	for file, classification := range allowlist {
+		assert.True(t, callerFiles[file],
+			"allowlist entry %q (%s) is stale — no call to ExportConfig found in that file; "+
+				"remove the entry if the call was refactored away", file, classification)
+	}
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -395,6 +395,11 @@ func loadConfigFromDB() (*config.Config, error) {
 		return nil, fmt.Errorf("failed to export configuration from database: %w", err)
 	}
 
+	// DB-loaded configs must run through ApplyDefaultsAndResolve to reach parity with YAML — see internal/config/parser.go.
+	if err := config.ApplyDefaultsAndResolve(cfg); err != nil {
+		return nil, fmt.Errorf("failed to apply defaults and resolve list references: %w", err)
+	}
+
 	// Validate configuration
 	if err := cfg.ValidateWithLogging(context.Background(), nil); err != nil {
 		return nil, fmt.Errorf("invalid configuration from database: %w", err)

--- a/internal/cli/sync_from_db_resolve_test.go
+++ b/internal/cli/sync_from_db_resolve_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"path/filepath"
 	"testing"
 
@@ -170,8 +169,7 @@ func TestSync_FromDB_MissingFileListRef_Errors(t *testing.T) {
 
 	_, err = loadConfigFromDB()
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, config.ErrListReferenceNotFound),
-		"expected ErrListReferenceNotFound in error chain, got: %v", err)
+	require.ErrorIs(t, err, config.ErrListReferenceNotFound)
 	assert.Contains(t, err.Error(), "available file_lists",
 		"error message should include 'available file_lists' hint from formatListNotFoundError")
 }

--- a/internal/cli/sync_from_db_resolve_test.go
+++ b/internal/cli/sync_from_db_resolve_test.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mrz1836/go-broadcast/internal/config"
+	"github.com/mrz1836/go-broadcast/internal/db"
+)
+
+// TestSync_FromDB_ResolvesFileListRefs asserts that file_list_refs entries are merged
+// into target.Files when the config is loaded from DB via loadConfigFromDB (AC-2).
+func TestSync_FromDB_ResolvesFileListRefs(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// setupTestDB wires target1 (acme/test-repo-1) → TargetFileListRef → ai-files.
+	// ai-files contains ".cursorrules". target1 also has inline ".editorconfig".
+	// After loadConfigFromDB resolves refs, both must appear in target.Files.
+	cfg, err := loadConfigFromDB()
+	require.NoError(t, err)
+	require.Len(t, cfg.Groups, 1)
+
+	var target *config.TargetConfig
+	for i := range cfg.Groups[0].Targets {
+		if cfg.Groups[0].Targets[i].Repo == "acme/test-repo-1" {
+			target = &cfg.Groups[0].Targets[i]
+			break
+		}
+	}
+	require.NotNil(t, target, "target acme/test-repo-1 not found in loaded config")
+
+	dests := make(map[string]bool, len(target.Files))
+	for _, f := range target.Files {
+		dests[f.Dest] = true
+	}
+	assert.True(t, dests[".cursorrules"], "expected .cursorrules from ai-files file_list_ref to be merged")
+	assert.True(t, dests[".editorconfig"], "expected .editorconfig from inline file mapping to be preserved")
+}
+
+// TestSync_FromDB_ResolvesDirectoryListRefs asserts that directory_list_refs entries are merged
+// into target.Directories when the config is loaded from DB via loadConfigFromDB (AC-3).
+func TestSync_FromDB_ResolvesDirectoryListRefs(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// setupTestDB wires target2 (acme/test-repo-2) → TargetDirectoryListRef → github-workflows.
+	// github-workflows starts with no entries; add one so we can assert the merge.
+	{
+		database, err := openDatabase()
+		require.NoError(t, err)
+		gormDB := database.DB()
+
+		var dl db.DirectoryList
+		require.NoError(t, gormDB.Where("external_id = ?", "github-workflows").First(&dl).Error)
+
+		require.NoError(t, gormDB.Create(&db.DirectoryMapping{
+			OwnerType: "directory_list",
+			OwnerID:   dl.ID,
+			Src:       ".github/workflows",
+			Dest:      ".github/workflows",
+			Position:  0,
+		}).Error)
+		require.NoError(t, database.Close())
+	}
+
+	cfg, err := loadConfigFromDB()
+	require.NoError(t, err)
+	require.Len(t, cfg.Groups, 1)
+
+	var target *config.TargetConfig
+	for i := range cfg.Groups[0].Targets {
+		if cfg.Groups[0].Targets[i].Repo == "acme/test-repo-2" {
+			target = &cfg.Groups[0].Targets[i]
+			break
+		}
+	}
+	require.NotNil(t, target, "target acme/test-repo-2 not found in loaded config")
+
+	require.NotEmpty(t, target.Directories, "expected directory from github-workflows directory_list_ref to be merged")
+	dests := make(map[string]bool, len(target.Directories))
+	for _, d := range target.Directories {
+		dests[d.Dest] = true
+	}
+	assert.True(t, dests[".github/workflows"], "expected .github/workflows from github-workflows ref")
+}
+
+// TestSync_FromDB_MissingFileListRef_Errors asserts that a target whose file_list_refs
+// point to a list absent from the config's FileLists surfaces ErrListReferenceNotFound
+// with the "available file_lists" hint, matching YAML-loader error parity (AC-4).
+func TestSync_FromDB_MissingFileListRef_Errors(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpPath := filepath.Join(tmpDir, "missing-ref.db")
+
+	oldDBPath := dbPath
+	dbPath = tmpPath
+	defer func() { dbPath = oldDBPath }()
+
+	// Build a DB where the main config has a target whose TargetFileListRef points to a
+	// file_list owned by a DIFFERENT config. ExportConfig for the main config will export
+	// the ref's ExternalID ("ghost-list") but won't include it in config.FileLists (only
+	// file_lists scoped to the main config_id are loaded). ApplyDefaultsAndResolve will
+	// then fail with ErrListReferenceNotFound.
+	database, err := db.Open(db.OpenOptions{Path: tmpPath, AutoMigrate: true})
+	require.NoError(t, err)
+	gormDB := database.DB()
+
+	// Main config — loaded first by loadConfigFromDB (lowest ID)
+	mainCfg := &db.Config{ExternalID: "main-config", Name: "Main Config", Version: 1}
+	require.NoError(t, gormDB.Create(mainCfg).Error)
+
+	// Auxiliary config — owns the ghost file_list
+	auxCfg := &db.Config{ExternalID: "aux-config", Name: "Aux Config", Version: 1}
+	require.NoError(t, gormDB.Create(auxCfg).Error)
+
+	// File list scoped to auxCfg — will NOT appear in main config's exported FileLists
+	ghostList := &db.FileList{
+		ConfigID:   auxCfg.ID,
+		ExternalID: "ghost-list",
+		Name:       "Ghost List",
+		Position:   0,
+	}
+	require.NoError(t, gormDB.Create(ghostList).Error)
+	require.NoError(t, gormDB.Create(&db.FileMapping{
+		OwnerType: "file_list",
+		OwnerID:   ghostList.ID,
+		Src:       "ghost.txt",
+		Dest:      "ghost.txt",
+		Position:  0,
+	}).Error)
+
+	// Minimal client / org / repo hierarchy for main config
+	client := &db.Client{Name: "acme-ghost"}
+	require.NoError(t, gormDB.Create(client).Error)
+	org := &db.Organization{ClientID: client.ID, Name: "acme-ghost"}
+	require.NoError(t, gormDB.Create(org).Error)
+	srcRepo := &db.Repo{OrganizationID: org.ID, Name: "go-broadcast"}
+	require.NoError(t, gormDB.Create(srcRepo).Error)
+	tgtRepo := &db.Repo{OrganizationID: org.ID, Name: "target-repo"}
+	require.NoError(t, gormDB.Create(tgtRepo).Error)
+
+	enabled := true
+	group := &db.Group{
+		ConfigID:   mainCfg.ID,
+		ExternalID: "test-group-ghost",
+		Name:       "Test Group",
+		Enabled:    &enabled,
+		Position:   0,
+	}
+	require.NoError(t, gormDB.Create(group).Error)
+	require.NoError(t, gormDB.Create(&db.Source{GroupID: group.ID, RepoID: srcRepo.ID, Branch: "main"}).Error)
+	require.NoError(t, gormDB.Create(&db.GroupGlobal{GroupID: group.ID}).Error)
+	require.NoError(t, gormDB.Create(&db.GroupDefault{GroupID: group.ID}).Error)
+
+	target := &db.Target{GroupID: group.ID, RepoID: tgtRepo.ID, Branch: "main", Position: 0}
+	require.NoError(t, gormDB.Create(target).Error)
+
+	// Cross-config ref: target under mainCfg → ghost-list under auxCfg
+	require.NoError(t, gormDB.Create(&db.TargetFileListRef{
+		TargetID:   target.ID,
+		FileListID: ghostList.ID,
+		Position:   0,
+	}).Error)
+
+	require.NoError(t, database.Close())
+
+	_, err = loadConfigFromDB()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, config.ErrListReferenceNotFound),
+		"expected ErrListReferenceNotFound in error chain, got: %v", err)
+	assert.Contains(t, err.Error(), "available file_lists",
+		"error message should include 'available file_lists' hint from formatListNotFoundError")
+}
+
+// TestSync_FromDB_InlineOverridesRef_OnDestCollision asserts that when the same dest
+// exists both as an inline target FileMapping and in a referenced file_list, the inline
+// entry wins (matching parser.go:267-270 precedence), and exactly one entry remains (AC-7).
+func TestSync_FromDB_InlineOverridesRef_OnDestCollision(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Add "shared.txt" to both ai-files (ref side, src="from-ref") and target1 inline
+	// (src="from-inline"). After resolve, only the inline entry should survive.
+	{
+		database, err := openDatabase()
+		require.NoError(t, err)
+		gormDB := database.DB()
+
+		var fl db.FileList
+		require.NoError(t, gormDB.Where("external_id = ?", "ai-files").First(&fl).Error)
+
+		var target1 db.Target
+		require.NoError(t, gormDB.Where("position = ?", 0).First(&target1).Error)
+
+		require.NoError(t, gormDB.Create(&db.FileMapping{
+			OwnerType: "file_list",
+			OwnerID:   fl.ID,
+			Src:       "from-ref",
+			Dest:      "shared.txt",
+			Position:  1,
+		}).Error)
+
+		require.NoError(t, gormDB.Create(&db.FileMapping{
+			OwnerType: "target",
+			OwnerID:   target1.ID,
+			Src:       "from-inline",
+			Dest:      "shared.txt",
+			Position:  1,
+		}).Error)
+
+		require.NoError(t, database.Close())
+	}
+
+	cfg, err := loadConfigFromDB()
+	require.NoError(t, err)
+	require.Len(t, cfg.Groups, 1)
+
+	var target *config.TargetConfig
+	for i := range cfg.Groups[0].Targets {
+		if cfg.Groups[0].Targets[i].Repo == "acme/test-repo-1" {
+			target = &cfg.Groups[0].Targets[i]
+			break
+		}
+	}
+	require.NotNil(t, target, "target acme/test-repo-1 not found")
+
+	var sharedEntries []config.FileMapping
+	for _, f := range target.Files {
+		if f.Dest == "shared.txt" {
+			sharedEntries = append(sharedEntries, f)
+		}
+	}
+	require.Len(t, sharedEntries, 1, "expected exactly one entry for shared.txt after dedup")
+	assert.Equal(t, "from-inline", sharedEntries[0].Src,
+		"inline entry must override ref entry when dest collides")
+}

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -133,6 +133,18 @@ func formatListNotFoundError(listType, ref, groupID, targetRepo string, fileList
 		listType, ref, groupID, targetRepo, hint, listType, availableIDs)
 }
 
+// ApplyDefaultsAndResolve applies defaults and resolves all file/directory list references on cfg.
+// Defaults must be applied before reference resolution; both steps are required for any *Config
+// returned from a loader (YAML or DB). Callers must not call applyDefaults or resolveListReferences
+// individually — use this function so the ordering is always enforced by the config package.
+func ApplyDefaultsAndResolve(cfg *Config) error {
+	applyDefaults(cfg)
+	if err := resolveListReferences(cfg); err != nil {
+		return fmt.Errorf("failed to resolve list references: %w", err)
+	}
+	return nil
+}
+
 // LoadFromReader parses configuration from an io.Reader
 func LoadFromReader(reader io.Reader) (*Config, error) {
 	config := &Config{}
@@ -144,12 +156,8 @@ func LoadFromReader(reader io.Reader) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
-	// Apply defaults
-	applyDefaults(config)
-
-	// Resolve list references
-	if err := resolveListReferences(config); err != nil {
-		return nil, fmt.Errorf("failed to resolve list references: %w", err)
+	if err := ApplyDefaultsAndResolve(config); err != nil {
+		return nil, err
 	}
 
 	return config, nil


### PR DESCRIPTION
## Summary
- export `config.ApplyDefaultsAndResolve` and call it from the DB-backed loader so `--from-db` sync, validate, status, cancel, and modules all honor `file_list_refs` and `directory_list_refs`
- resolve list references on the DB side of `db diff --from-db` so DB vs YAML diffs match on `file_list_refs`-bearing configs
- lock in `db export`'s deliberate unresolved round-trip with a regression test

## Validation
- `go test ./internal/cli ./internal/db ./internal/config -count=1 -race`
- `golangci-lint run ./internal/cli/... ./internal/db/... ./internal/config/...`
- manual smoke: `go-broadcast sync --dry-run --from-db --targets <one-target>` against a local DB carrying `file_list_refs`; observed previously-dropped list entries now considered

## Notes
- The YAML loader behavior is byte-identical; only the DB path gains parity.
- `db export` continues to preserve refs un-inlined on round-trip; a new regression test asserts this.
