### PR TITLE
[Sync] Update project files from source repository (c1a67fe)

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -93,11 +93,14 @@ jobs:
         # SECURITY: pin the checkout to the trusted base ref so the local
         # ./.github/actions/load-env action (run below with pull-requests/issues write)
         # can never be a PR-controlled version. Default checkout on pull_request /
-        # pull_request_review events resolves to the PR head, which is attacker-influenced.
-        # Env files and the action are not modified by PRs, so base-ref loading is safe.
+        # pull_request_review events resolves to the PR merge ref, which is attacker-influenced.
+        # `github.base_ref` is ONLY populated for pull_request / pull_request_target — it is
+        # empty on pull_request_review, where `github.ref` is refs/pull/<n>/merge (PR-controlled).
+        # Read the base branch directly from the event payload so it is the trusted base ref for
+        # BOTH triggers. Env files and the action are not modified there, so base-ref loading is safe.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.base_ref || github.ref }}
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
           sparse-checkout: |
             .github/env


### PR DESCRIPTION
## What Changed

* Updated the `ref` parameter in the checkout action from `${{ github.base_ref || github.ref }}` to `${{ github.event.pull_request.base.ref }}`
* Expanded security comment to clarify that `pull_request_review` events resolve to the PR merge ref (not head ref)
* Added explanation that `github.base_ref` is only populated for `pull_request` / `pull_request_target` events and is empty on `pull_request_review`
* Updated comment to document that the base branch is now read directly from the event payload for consistent trusted base ref across both trigger types

## Why It Was Necessary

* The previous approach using `github.base_ref || github.ref` was unreliable because `github.base_ref` is empty on `pull_request_review` events
* On `pull_request_review` events, `github.ref` resolves to `refs/pull/<n>/merge`, which is attacker-influenced and creates a security risk
* Reading from `github.event.pull_request.base.ref` ensures the checkout always uses the trusted base branch regardless of trigger type

## Testing Performed

* Verify workflow runs successfully on both `pull_request` and `pull_request_review` trigger events
* Confirm the checkout action correctly resolves to the base branch in both scenarios
* Validate that the `.github/actions/load-env` action loads configuration from the trusted base ref only

## Impact / Risk

* **Security improvement**: Eliminates potential attack vector where PR-controlled code could be executed with elevated permissions
* **Low risk**: Change affects only the ref resolution logic; the checkout action behavior remains the same when properly configured
* **No breaking changes**: Workflow continues to function identically for legitimate use cases while closing a security gap

<!-- go-broadcast-metadata
group:
  id: fortress-to-broadcast
  name: fortress-to-broadcast
diff_info:
  staged_repo_available: true
  changed_files_count: 1
  files_with_original_content: 1
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-fortress
  source_commit: c1a67feac97278704e86889e677d557d4cd8cced
  target_repo: mrz1836/go-broadcast
  sync_commit: ca902be68c50ee449f7575e420c9c0c426b7bb8f
  sync_time: 2026-05-29T14:37:06-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/actions
    dest: .github/actions
    excluded: ["cache-act-images", "setup-guardian-tools"]
    files_synced: 0
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 839
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 367
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["fortress-guardian.yml"]
    files_synced: 1
    files_examined: 20
    files_excluded: 1
    processing_time_ms: 914
performance:
  total_files: 51
-->
