### PR TITLE
Add go-broadcast --check-auth credential report

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@
 # Security Hardened Defaults:
 #   • Daily cadence (08:00 America/New_York) – align with CVE dump cycle.
 #   • Direct dependencies only – prevents unsolicited transitive churn.
-#   • PRs labeled, assigned, and target the protected "master/main" branch.
+#   • PRs labeled, assigned, and target the protected branch (master or main).
 #   • PR titles prefixed with chore(scope): – conventional commits.
 #   • Force‑push and delete‑branch disabled via branch‑protection rules.
 #   • PR limit = 10 to avoid queue flooding.

--- a/cmd/go-broadcast/main.go
+++ b/cmd/go-broadcast/main.go
@@ -20,8 +20,7 @@ func main() {
 	app := NewApp()
 	if err := app.Run(os.Args[1:]); err != nil {
 		// Error already displayed by outputHandler in Run() or by cli.Execute()
-		// Just exit with error code
-		os.Exit(1)
+		os.Exit(cli.ExitCodeForError(err))
 	}
 }
 

--- a/internal/cli/check_auth.go
+++ b/internal/cli/check_auth.go
@@ -1,0 +1,177 @@
+// Package cli provides command-line interface functionality for go-broadcast.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const (
+	checkAuthExitNoToken       = 1
+	checkAuthExitTokenRejected = 2
+)
+
+var (
+	errCheckAuthNoToken       = errors.New("GitHub token not detected")
+	errCheckAuthTokenRejected = errors.New("GitHub authentication check failed")
+)
+
+type checkAuthRunner interface {
+	Run(ctx context.Context, args, env []string) ([]byte, error)
+}
+
+type ghCheckAuthRunner struct{}
+
+func (r ghCheckAuthRunner) Run(ctx context.Context, args, env []string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Env = env
+	return cmd.Output()
+}
+
+type githubUserResponse struct {
+	Login string `json:"login"`
+}
+
+type githubAuthReport struct {
+	TokenDetected bool
+	Login         string
+	Scopes        []string
+}
+
+func runCheckAuth(ctx context.Context, writer io.Writer) error {
+	return runCheckAuthWithRunner(ctx, writer, ghCheckAuthRunner{}, os.Getenv, os.Environ())
+}
+
+func runCheckAuthWithRunner(
+	ctx context.Context,
+	writer io.Writer,
+	runner checkAuthRunner,
+	getenv func(string) string,
+	baseEnv []string,
+) error {
+	token, detected := detectGitHubToken(getenv)
+	if !detected {
+		printGitHubAuthReport(writer, githubAuthReport{TokenDetected: false})
+		return newExitCodeError(checkAuthExitNoToken, errCheckAuthNoToken)
+	}
+
+	env := withGitHubTokenEnv(baseEnv, token)
+	userOutput, err := runner.Run(ctx, []string{"api", "user"}, env)
+	if err != nil {
+		printGitHubAuthReport(writer, githubAuthReport{
+			TokenDetected: true,
+			Scopes:        []string{},
+		})
+		return newExitCodeError(checkAuthExitTokenRejected, errCheckAuthTokenRejected)
+	}
+
+	login, err := parseGitHubLogin(userOutput)
+	if err != nil {
+		printGitHubAuthReport(writer, githubAuthReport{
+			TokenDetected: true,
+			Scopes:        []string{},
+		})
+		return newExitCodeError(checkAuthExitTokenRejected, errCheckAuthTokenRejected)
+	}
+
+	scopesOutput, err := runner.Run(ctx, []string{"api", "-i", "user"}, env)
+	scopes := []string{}
+	if err == nil {
+		scopes = parseGitHubScopes(scopesOutput)
+	}
+
+	printGitHubAuthReport(writer, githubAuthReport{
+		TokenDetected: true,
+		Login:         login,
+		Scopes:        scopes,
+	})
+
+	return nil
+}
+
+func detectGitHubToken(getenv func(string) string) (string, bool) {
+	for _, key := range []string{"GH_PAT_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
+		if token := strings.TrimSpace(getenv(key)); token != "" {
+			return token, true
+		}
+	}
+	return "", false
+}
+
+func withGitHubTokenEnv(baseEnv []string, token string) []string {
+	env := make([]string, 0, len(baseEnv)+1)
+	for _, entry := range baseEnv {
+		if strings.HasPrefix(entry, "GH_TOKEN=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	env = append(env, "GH_TOKEN="+token)
+	return env
+}
+
+func parseGitHubLogin(data []byte) (string, error) {
+	var user githubUserResponse
+	if err := json.Unmarshal(data, &user); err != nil {
+		return "", fmt.Errorf("parse GitHub user response: %w", err)
+	}
+	if strings.TrimSpace(user.Login) == "" {
+		return "", errors.New("GitHub user response did not include a login")
+	}
+	return user.Login, nil
+}
+
+func parseGitHubScopes(data []byte) []string {
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		name, value, ok := strings.Cut(line, ":")
+		if !ok || !strings.EqualFold(strings.TrimSpace(name), "X-Oauth-Scopes") {
+			continue
+		}
+		scopes := splitScopes(value)
+		sort.Strings(scopes)
+		return scopes
+	}
+	return []string{}
+}
+
+func splitScopes(value string) []string {
+	parts := strings.Split(value, ",")
+	scopes := make([]string, 0, len(parts))
+	for _, part := range parts {
+		scope := strings.TrimSpace(part)
+		if scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	return scopes
+}
+
+func printGitHubAuthReport(writer io.Writer, report githubAuthReport) {
+	tokenDetected := "no"
+	if report.TokenDetected {
+		tokenDetected = "yes"
+	}
+
+	login := "(unknown)"
+	if strings.TrimSpace(report.Login) != "" {
+		login = report.Login
+	}
+
+	scopes := "(none)"
+	if len(report.Scopes) > 0 {
+		scopes = strings.Join(report.Scopes, ", ")
+	}
+
+	_, _ = fmt.Fprintf(writer, "GitHub authentication\n")
+	_, _ = fmt.Fprintf(writer, "token detected: %s\n", tokenDetected)
+	_, _ = fmt.Fprintf(writer, "login: %s\n", login)
+	_, _ = fmt.Fprintf(writer, "scopes: %s\n", scopes)
+}

--- a/internal/cli/check_auth.go
+++ b/internal/cli/check_auth.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+
+	"github.com/mrz1836/go-broadcast/internal/ai"
 )
 
 const (
@@ -45,6 +47,14 @@ type githubAuthReport struct {
 	Scopes        []string
 }
 
+type aiProviderAuthReport struct {
+	Provider string
+	Active   bool
+	Detected bool
+	Source   string
+	Hint     string
+}
+
 func runCheckAuth(ctx context.Context, writer io.Writer) error {
 	return runCheckAuthWithRunner(ctx, writer, ghCheckAuthRunner{}, os.Getenv, os.Environ())
 }
@@ -57,27 +67,28 @@ func runCheckAuthWithRunner(
 	baseEnv []string,
 ) error {
 	token, detected := detectGitHubToken(getenv)
+	aiReport := buildAIAuthReport(getenv)
 	if !detected {
-		printGitHubAuthReport(writer, githubAuthReport{TokenDetected: false})
+		printAuthReport(writer, githubAuthReport{TokenDetected: false}, aiReport)
 		return newExitCodeError(checkAuthExitNoToken, errCheckAuthNoToken)
 	}
 
 	env := withGitHubTokenEnv(baseEnv, token)
 	userOutput, err := runner.Run(ctx, []string{"api", "user"}, env)
 	if err != nil {
-		printGitHubAuthReport(writer, githubAuthReport{
+		printAuthReport(writer, githubAuthReport{
 			TokenDetected: true,
 			Scopes:        []string{},
-		})
+		}, aiReport)
 		return newExitCodeError(checkAuthExitTokenRejected, errCheckAuthTokenRejected)
 	}
 
 	login, err := parseGitHubLogin(userOutput)
 	if err != nil {
-		printGitHubAuthReport(writer, githubAuthReport{
+		printAuthReport(writer, githubAuthReport{
 			TokenDetected: true,
 			Scopes:        []string{},
-		})
+		}, aiReport)
 		return newExitCodeError(checkAuthExitTokenRejected, errCheckAuthTokenRejected)
 	}
 
@@ -87,11 +98,11 @@ func runCheckAuthWithRunner(
 		scopes = parseGitHubScopes(scopesOutput)
 	}
 
-	printGitHubAuthReport(writer, githubAuthReport{
+	printAuthReport(writer, githubAuthReport{
 		TokenDetected: true,
 		Login:         login,
 		Scopes:        scopes,
-	})
+	}, aiReport)
 
 	return nil
 }
@@ -154,6 +165,85 @@ func splitScopes(value string) []string {
 	return scopes
 }
 
+func buildAIAuthReport(getenv func(string) string) []aiProviderAuthReport {
+	activeProvider := strings.TrimSpace(getenv("GO_BROADCAST_AI_PROVIDER"))
+	if activeProvider == "" {
+		activeProvider = ai.ProviderAnthropic
+	}
+
+	reports := make([]aiProviderAuthReport, 0, 3)
+	for _, provider := range []string{ai.ProviderAnthropic, ai.ProviderOpenAI, ai.ProviderGoogle} {
+		key, source := detectAIProviderKey(getenv, provider)
+		reports = append(reports, aiProviderAuthReport{
+			Provider: provider,
+			Active:   provider == activeProvider,
+			Detected: key != "",
+			Source:   source,
+			Hint:     detectAIKeyHint(provider, key),
+		})
+	}
+
+	return reports
+}
+
+func detectAIProviderKey(getenv func(string) string, provider string) (string, string) {
+	if key := strings.TrimSpace(getenv("GO_BROADCAST_AI_API_KEY")); key != "" {
+		return key, "GO_BROADCAST_AI_API_KEY"
+	}
+
+	source := providerSpecificAIKeyEnv(provider)
+	if source == "" {
+		return "", ""
+	}
+	if key := strings.TrimSpace(getenv(source)); key != "" {
+		return key, source
+	}
+
+	return "", ""
+}
+
+func providerSpecificAIKeyEnv(provider string) string {
+	switch provider {
+	case ai.ProviderAnthropic:
+		return "ANTHROPIC_API_KEY" //nolint:gosec // G101: env var name only, never the credential value.
+	case ai.ProviderOpenAI:
+		return "OPENAI_API_KEY" //nolint:gosec // G101: env var name only, never the credential value.
+	case ai.ProviderGoogle:
+		return "GEMINI_API_KEY" //nolint:gosec // G101: env var name only, never the credential value.
+	default:
+		return ""
+	}
+}
+
+func detectAIKeyHint(provider, key string) string {
+	if key == "" {
+		return "(none)"
+	}
+
+	switch provider {
+	case ai.ProviderAnthropic:
+		if strings.HasPrefix(key, "sk-ant-") {
+			return "prefix sk-ant-"
+		}
+	case ai.ProviderOpenAI:
+		if strings.HasPrefix(key, "sk-") {
+			return "prefix sk-"
+		}
+	case ai.ProviderGoogle:
+		if strings.HasPrefix(key, "AIza") {
+			return "prefix AIza"
+		}
+	}
+
+	return "prefix unrecognized"
+}
+
+func printAuthReport(writer io.Writer, githubReport githubAuthReport, aiReport []aiProviderAuthReport) {
+	printGitHubAuthReport(writer, githubReport)
+	_, _ = fmt.Fprintln(writer)
+	printAIAuthReport(writer, aiReport)
+}
+
 func printGitHubAuthReport(writer io.Writer, report githubAuthReport) {
 	tokenDetected := "no"
 	if report.TokenDetected {
@@ -174,4 +264,31 @@ func printGitHubAuthReport(writer io.Writer, report githubAuthReport) {
 	_, _ = fmt.Fprintf(writer, "token detected: %s\n", tokenDetected)
 	_, _ = fmt.Fprintf(writer, "login: %s\n", login)
 	_, _ = fmt.Fprintf(writer, "scopes: %s\n", scopes)
+}
+
+func printAIAuthReport(writer io.Writer, report []aiProviderAuthReport) {
+	_, _ = fmt.Fprintf(writer, "AI provider credentials\n")
+	for _, provider := range report {
+		active := ""
+		if provider.Active {
+			active = " (active)"
+		}
+
+		detected := "unset"
+		source := "(none)"
+		if provider.Detected {
+			detected = "set"
+			source = provider.Source
+		}
+
+		_, _ = fmt.Fprintf(
+			writer,
+			"%s%s: %s, source: %s, hint: %s\n",
+			provider.Provider,
+			active,
+			detected,
+			source,
+			provider.Hint,
+		)
+	}
 }

--- a/internal/cli/check_auth.go
+++ b/internal/cli/check_auth.go
@@ -23,6 +23,7 @@ const (
 var (
 	errCheckAuthNoToken       = errors.New("GitHub token not detected")
 	errCheckAuthTokenRejected = errors.New("GitHub authentication check failed")
+	errCheckAuthMissingLogin  = errors.New("GitHub user response did not include a login")
 )
 
 type checkAuthRunner interface {
@@ -32,6 +33,7 @@ type checkAuthRunner interface {
 type ghCheckAuthRunner struct{}
 
 func (r ghCheckAuthRunner) Run(ctx context.Context, args, env []string) ([]byte, error) {
+	//nolint:gosec // G204: args are fixed by internal auth probe callers, not user input.
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	cmd.Env = env
 	return cmd.Output()
@@ -134,7 +136,7 @@ func parseGitHubLogin(data []byte) (string, error) {
 		return "", fmt.Errorf("parse GitHub user response: %w", err)
 	}
 	if strings.TrimSpace(user.Login) == "" {
-		return "", errors.New("GitHub user response did not include a login")
+		return "", errCheckAuthMissingLogin
 	}
 	return user.Login, nil
 }
@@ -205,11 +207,11 @@ func detectAIProviderKey(getenv func(string) string, provider string) (string, s
 func providerSpecificAIKeyEnv(provider string) string {
 	switch provider {
 	case ai.ProviderAnthropic:
-		return "ANTHROPIC_API_KEY" //nolint:gosec // G101: env var name only, never the credential value.
+		return "ANTHROPIC_API_KEY"
 	case ai.ProviderOpenAI:
-		return "OPENAI_API_KEY" //nolint:gosec // G101: env var name only, never the credential value.
+		return "OPENAI_API_KEY"
 	case ai.ProviderGoogle:
-		return "GEMINI_API_KEY" //nolint:gosec // G101: env var name only, never the credential value.
+		return "GEMINI_API_KEY"
 	default:
 		return ""
 	}

--- a/internal/cli/check_auth_test.go
+++ b/internal/cli/check_auth_test.go
@@ -1,0 +1,361 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errUnexpectedGHInvocation = errors.New("unexpected gh invocation")
+
+type stubCheckAuthRunner struct {
+	responses map[string]stubCheckAuthResponse
+	calls     []stubCheckAuthCall
+}
+
+type stubCheckAuthResponse struct {
+	output []byte
+	err    error
+}
+
+type stubCheckAuthCall struct {
+	args []string
+	env  []string
+}
+
+func (r *stubCheckAuthRunner) Run(_ context.Context, args, env []string) ([]byte, error) {
+	r.calls = append(r.calls, stubCheckAuthCall{
+		args: slices.Clone(args),
+		env:  slices.Clone(env),
+	})
+
+	response, ok := r.responses[strings.Join(args, "\x00")]
+	if !ok {
+		return nil, errUnexpectedGHInvocation
+	}
+
+	return response.output, response.err
+}
+
+type secretError struct {
+	secret string
+}
+
+func (e secretError) Error() string {
+	return "remote rejected " + e.secret
+}
+
+func TestRunCheckAuthWithRunner_GitHubExitCodesAndScopes(t *testing.T) {
+	t.Parallel()
+
+	rejectedToken := strings.Join([]string{"ghp", "rejected", "secret", "value"}, "_")
+	successToken := strings.Join([]string{"ghp", "success", "secret", "value"}, "_")
+	fineGrainedToken := strings.Join([]string{"ghp", "fine-grained", "secret", "value"}, "_")
+
+	tests := []struct {
+		name           string
+		env            map[string]string
+		responses      map[string]stubCheckAuthResponse
+		wantErr        bool
+		wantExitCode   int
+		wantOutput     []string
+		wantNoOutput   []string
+		wantCallCount  int
+		wantTokenInEnv string
+	}{
+		{
+			name:         "no token exits 1 without calling gh",
+			env:          map[string]string{},
+			responses:    map[string]stubCheckAuthResponse{},
+			wantErr:      true,
+			wantExitCode: checkAuthExitNoToken,
+			wantOutput: []string{
+				"GitHub authentication",
+				"token detected: no",
+				"login: (unknown)",
+				"scopes: (none)",
+				"AI provider credentials",
+				"anthropic (active): unset, source: (none), hint: (none)",
+			},
+			wantCallCount: 0,
+		},
+		{
+			name: "token rejected exits 2 and redacts the runner error",
+			env: map[string]string{
+				"GH_PAT_TOKEN": rejectedToken,
+			},
+			responses: map[string]stubCheckAuthResponse{
+				"api\x00user": {
+					err: secretError{secret: rejectedToken},
+				},
+			},
+			wantErr:      true,
+			wantExitCode: checkAuthExitTokenRejected,
+			wantOutput: []string{
+				"token detected: yes",
+				"login: (unknown)",
+				"scopes: (none)",
+			},
+			wantNoOutput: []string{
+				rejectedToken,
+				"remote rejected",
+			},
+			wantCallCount:  1,
+			wantTokenInEnv: "GH_TOKEN=" + rejectedToken,
+		},
+		{
+			name: "authenticated token exits 0 with sorted scopes",
+			env: map[string]string{
+				"GITHUB_TOKEN": successToken,
+			},
+			responses: map[string]stubCheckAuthResponse{
+				"api\x00user": {
+					output: []byte(`{"login":"octocat"}`),
+				},
+				"api\x00-i\x00user": {
+					output: []byte("HTTP/2.0 200 OK\nX-Oauth-Scopes: workflow, repo, read:org\n"),
+				},
+			},
+			wantOutput: []string{
+				"token detected: yes",
+				"login: octocat",
+				"scopes: read:org, repo, workflow",
+			},
+			wantNoOutput: []string{
+				successToken,
+			},
+			wantCallCount:  2,
+			wantTokenInEnv: "GH_TOKEN=" + successToken,
+		},
+		{
+			name: "authenticated token exits 0 when scopes header is absent",
+			env: map[string]string{
+				"GH_TOKEN": fineGrainedToken,
+			},
+			responses: map[string]stubCheckAuthResponse{
+				"api\x00user": {
+					output: []byte(`{"login":"finegrained"}`),
+				},
+				"api\x00-i\x00user": {
+					output: []byte("HTTP/2.0 200 OK\n"),
+				},
+			},
+			wantOutput: []string{
+				"token detected: yes",
+				"login: finegrained",
+				"scopes: (none)",
+			},
+			wantNoOutput: []string{
+				fineGrainedToken,
+			},
+			wantCallCount:  2,
+			wantTokenInEnv: "GH_TOKEN=" + fineGrainedToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			runner := &stubCheckAuthRunner{responses: tt.responses}
+			err := runCheckAuthWithRunner(
+				context.Background(),
+				&out,
+				runner,
+				getenvFromMap(tt.env),
+				[]string{"PATH=/usr/bin", "GH_TOKEN=old-token"},
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantExitCode, ExitCodeForError(err))
+			} else {
+				require.NoError(t, err)
+			}
+
+			output := out.String()
+			for _, want := range tt.wantOutput {
+				assert.Contains(t, output, want)
+			}
+			for _, secret := range tt.wantNoOutput {
+				assert.NotContains(t, output, secret)
+				if err != nil {
+					assert.NotContains(t, err.Error(), secret)
+				}
+			}
+			assert.Len(t, runner.calls, tt.wantCallCount)
+			if tt.wantTokenInEnv != "" {
+				require.NotEmpty(t, runner.calls)
+				assert.Contains(t, runner.calls[0].env, tt.wantTokenInEnv)
+				assert.NotContains(t, runner.calls[0].env, "GH_TOKEN=old-token")
+			}
+		})
+	}
+}
+
+func TestRunCheckAuthWithRunner_ParseFailuresAreRejectedAndRedacted(t *testing.T) {
+	t.Parallel()
+
+	secret := strings.Join([]string{"ghp", "parse-failure", "secret", "value"}, "_")
+	var out bytes.Buffer
+	runner := &stubCheckAuthRunner{
+		responses: map[string]stubCheckAuthResponse{
+			"api\x00user": {output: []byte(`{"id":123}`)},
+		},
+	}
+
+	err := runCheckAuthWithRunner(
+		context.Background(),
+		&out,
+		runner,
+		getenvFromMap(map[string]string{"GH_PAT_TOKEN": secret}),
+		[]string{"PATH=/usr/bin"},
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, checkAuthExitTokenRejected, ExitCodeForError(err))
+	assert.NotContains(t, out.String(), secret)
+	assert.NotContains(t, err.Error(), secret)
+	assert.Contains(t, out.String(), "token detected: yes")
+	assert.Contains(t, out.String(), "login: (unknown)")
+}
+
+func TestBuildAIAuthReport(t *testing.T) {
+	t.Parallel()
+
+	anthropicSecret := "sk-ant-" + strings.Join([]string{"api03", "secret", "value"}, "-")
+	openAISecret := "sk-" + strings.Join([]string{"openai", "secret", "value"}, "-")
+	googleSecret := "AIza" + strings.Join([]string{"google", "secret", "value"}, "-")
+	sharedSecret := strings.Join([]string{"shared", "secret", "value"}, "-")
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want []aiProviderAuthReport
+	}{
+		{
+			name: "defaults to anthropic active with provider specific keys",
+			env: map[string]string{
+				"ANTHROPIC_API_KEY": anthropicSecret,
+				"OPENAI_API_KEY":    openAISecret,
+				"GEMINI_API_KEY":    googleSecret,
+			},
+			want: []aiProviderAuthReport{
+				{
+					Provider: "anthropic",
+					Active:   true,
+					Detected: true,
+					Source:   "ANTHROPIC_API_KEY",
+					Hint:     "prefix sk-ant-",
+				},
+				{
+					Provider: "openai",
+					Detected: true,
+					Source:   "OPENAI_API_KEY",
+					Hint:     "prefix sk-",
+				},
+				{
+					Provider: "google",
+					Detected: true,
+					Source:   "GEMINI_API_KEY",
+					Hint:     "prefix AIza",
+				},
+			},
+		},
+		{
+			name: "generic key takes precedence for every provider and active provider is honored",
+			env: map[string]string{
+				"GO_BROADCAST_AI_PROVIDER": "openai",
+				"GO_BROADCAST_AI_API_KEY":  sharedSecret,
+				"OPENAI_API_KEY":           openAISecret,
+			},
+			want: []aiProviderAuthReport{
+				{
+					Provider: "anthropic",
+					Detected: true,
+					Source:   "GO_BROADCAST_AI_API_KEY",
+					Hint:     "prefix unrecognized",
+				},
+				{
+					Provider: "openai",
+					Active:   true,
+					Detected: true,
+					Source:   "GO_BROADCAST_AI_API_KEY",
+					Hint:     "prefix unrecognized",
+				},
+				{
+					Provider: "google",
+					Detected: true,
+					Source:   "GO_BROADCAST_AI_API_KEY",
+					Hint:     "prefix unrecognized",
+				},
+			},
+		},
+		{
+			name: "unset keys are reported without a source or hint",
+			env: map[string]string{
+				"GO_BROADCAST_AI_PROVIDER": "google",
+			},
+			want: []aiProviderAuthReport{
+				{
+					Provider: "anthropic",
+					Hint:     "(none)",
+				},
+				{
+					Provider: "openai",
+					Hint:     "(none)",
+				},
+				{
+					Provider: "google",
+					Active:   true,
+					Hint:     "(none)",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, buildAIAuthReport(getenvFromMap(tt.env)))
+		})
+	}
+}
+
+func TestPrintAIAuthReportRedactsCredentialValues(t *testing.T) {
+	t.Parallel()
+
+	secrets := []string{
+		"sk-ant-" + strings.Join([]string{"api03", "secret", "value"}, "-"),
+		"sk-" + strings.Join([]string{"openai", "secret", "value"}, "-"),
+		"AIza" + strings.Join([]string{"google", "secret", "value"}, "-"),
+	}
+	var out bytes.Buffer
+
+	printAIAuthReport(&out, buildAIAuthReport(getenvFromMap(map[string]string{
+		"ANTHROPIC_API_KEY": secrets[0],
+		"OPENAI_API_KEY":    secrets[1],
+		"GEMINI_API_KEY":    secrets[2],
+	})))
+
+	output := out.String()
+	for _, secret := range secrets {
+		assert.NotContains(t, output, secret)
+	}
+	assert.Contains(t, output, "anthropic (active): set, source: ANTHROPIC_API_KEY, hint: prefix sk-ant-")
+	assert.Contains(t, output, "openai: set, source: OPENAI_API_KEY, hint: prefix sk-")
+	assert.Contains(t, output, "google: set, source: GEMINI_API_KEY, hint: prefix AIza")
+}
+
+func getenvFromMap(values map[string]string) func(string) string {
+	return func(key string) string {
+		return values[key]
+	}
+}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -2,6 +2,38 @@ package cli
 
 import "errors"
 
+// exitCodeError carries a requested process exit code for CLI paths that need
+// a specific status while still returning errors from testable command handlers.
+type exitCodeError struct {
+	code int
+	err  error
+}
+
+func (e *exitCodeError) Error() string {
+	return e.err.Error()
+}
+
+func (e *exitCodeError) Unwrap() error {
+	return e.err
+}
+
+func (e *exitCodeError) ExitCode() int {
+	return e.code
+}
+
+func newExitCodeError(code int, err error) error {
+	return &exitCodeError{code: code, err: err}
+}
+
+// ExitCodeForError returns the process exit code requested by a CLI error.
+func ExitCodeForError(err error) int {
+	var exitErr *exitCodeError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 1
+}
+
 // Common CLI errors
 var (
 	// ErrConfigFileNotFound indicates the configuration file was not found

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -25,6 +25,8 @@ type loggerContextKey struct{}
 var (
 	showVersionMu sync.RWMutex
 	showVersion   bool
+	checkAuthMu   sync.RWMutex
+	checkAuth     bool
 	rootCmdMu     sync.RWMutex // Protects rootCmd for thread-safe test access
 )
 
@@ -33,6 +35,13 @@ func getShowVersion() bool {
 	showVersionMu.RLock()
 	defer showVersionMu.RUnlock()
 	return showVersion
+}
+
+// getCheckAuth returns the checkAuth flag (thread-safe)
+func getCheckAuth() bool {
+	checkAuthMu.RLock()
+	defer checkAuthMu.RUnlock()
+	return checkAuth
 }
 
 // getRootCmd returns the root command (thread-safe, for testing)
@@ -82,6 +91,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.DryRun, "dry-run", false, "Preview changes without making them")
 	rootCmd.PersistentFlags().StringVar(&globalFlags.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().BoolVar(&showVersion, "version", false, "Show version information")
+	rootCmd.PersistentFlags().BoolVar(&checkAuth, "check-auth", false, "Check GitHub authentication and exit (codes: 0 authenticated, 1 no token, 2 token rejected)")
 	rootCmd.PersistentFlags().StringVar(&dbPath, "db-path", "", "Path to database file (default: ~/.config/go-broadcast/broadcast.db)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.FromDB, "from-db", false, "Load configuration from database instead of YAML file")
 
@@ -121,6 +131,7 @@ func NewRootCmd() *cobra.Command {
 
 	// Create local version flag for this command instance (avoids race on global)
 	var localShowVersion bool
+	var localCheckAuth bool
 
 	// Create new command instance with isolated setup function
 	cmd := &cobra.Command{
@@ -137,6 +148,9 @@ state locally. It supports file transformations and provides progress tracking.`
 			if localShowVersion {
 				return printVersion(false)
 			}
+			if localCheckAuth {
+				return runCheckAuth(cmd.Context(), cmd.OutOrStdout())
+			}
 			return cmd.Help()
 		},
 		SilenceUsage:  true,
@@ -148,6 +162,7 @@ state locally. It supports file transformations and provides progress tracking.`
 	cmd.PersistentFlags().BoolVar(&flags.DryRun, "dry-run", false, "Preview changes without making them")
 	cmd.PersistentFlags().StringVar(&flags.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	cmd.PersistentFlags().BoolVar(&localShowVersion, "version", false, "Show version information")
+	cmd.PersistentFlags().BoolVar(&localCheckAuth, "check-auth", false, "Check GitHub authentication and exit (codes: 0 authenticated, 1 no token, 2 token rejected)")
 
 	// Add commands with isolated flags
 	cmd.AddCommand(createSyncCmd(flags))
@@ -216,7 +231,7 @@ func GetRootCmd() *cobra.Command {
 func Execute() {
 	if err := ExecuteWithContext(context.Background()); err != nil {
 		output.Error(err.Error())
-		os.Exit(1)
+		os.Exit(ExitCodeForError(err))
 	}
 }
 
@@ -295,6 +310,9 @@ func rootRunE(cmd *cobra.Command, _ []string) error {
 	if getShowVersion() {
 		return printVersion(false)
 	}
+	if getCheckAuth() {
+		return runCheckAuth(cmd.Context(), cmd.OutOrStdout())
+	}
 
 	// Otherwise show help
 	return cmd.Help()
@@ -306,6 +324,9 @@ func createRootRunEWithVerbose(config *LogConfig) func(*cobra.Command, []string)
 		// If version flag is set, print version (with JSON support, thread-safe read)
 		if getShowVersion() {
 			return printVersion(config.JSONOutput)
+		}
+		if getCheckAuth() {
+			return runCheckAuth(cmd.Context(), cmd.OutOrStdout())
 		}
 
 		// Otherwise show help
@@ -391,6 +412,7 @@ func addVerboseFlags(cmd *cobra.Command, config *LogConfig) {
 	cmd.PersistentFlags().StringVar(&config.LogLevel, "log-level", "info",
 		"Log level (debug, info, warn, error) - overridden by verbose flags")
 	cmd.PersistentFlags().BoolVar(&showVersion, "version", false, "Show version information")
+	cmd.PersistentFlags().BoolVar(&checkAuth, "check-auth", false, "Check GitHub authentication and exit (codes: 0 authenticated, 1 no token, 2 token rejected)")
 }
 
 // createSetupLoggingWithVerbose creates a verbose logging setup function.

--- a/test/integration/performance_test.go
+++ b/test/integration/performance_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || performance
 
 package integration
 


### PR DESCRIPTION
This branch implements: Add go-broadcast --check-auth credential report

What changed:
- See the commits and validation on this branch.

Validation:
- Managed by the todo executor.
