### PR TITLE
Harden go-broadcast: honor target/group scope + blast-radius confirmation guard (prevent accidental all-groups sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,48 @@ the over-budget halt message, see
 
 <br/>
 
+### Blast-radius confirmation guard
+
+`sync` is designed around a **one-group-at-a-time default**: scope is resolved up
+front, so `sync org/repo` and `--groups`/`--skip-groups` always narrow the run to
+exactly what you named, even when the configuration holds many groups. The resolved
+scope (groups, repo list, repo count, estimated writes) is printed **before any
+write on every invocation** — not only under `--dry-run`.
+
+On top of that, a separate **blast-radius confirmation guard** trips when the
+resolved scope is large — **more than 1 group OR more than 5 repositories**. A
+large sync cannot write until it is explicitly confirmed:
+
+- **Interactive (TTY):** the guard lists every group and repository it will touch
+  and requires you to type the exact **resolved repository count** before it
+  proceeds. Any other value aborts with zero writes.
+- **Non-interactive (agents, CI, no TTY):** the guard **hard-refuses** (non-zero
+  exit, zero writes) unless you pass `--confirm-scope=<N>`, where `N` equals the
+  resolved repository count. A boolean always-pass token is intentionally not
+  accepted, so a single-group command copied into a multi-group context fails
+  closed. `N` is always the **repository** count — for a single group syncing 6
+  repos, `--confirm-scope=1` is rejected and `--confirm-scope=6` proceeds.
+
+This guard is independent of the rate-limit preflight:
+`--ignore-rate-limit-preflight` cannot widen scope and does **not** bypass it.
+
+```bash
+# Small single-group sync (<=5 repos): runs without confirmation
+go-broadcast sync --config sync.yaml --groups core
+
+# Large sync (>1 group or >5 repos), non-interactive: confirm the repo count
+go-broadcast sync --config sync.yaml --groups "core,security" --confirm-scope 12
+
+# --ignore-rate-limit-preflight does NOT bypass the guard
+go-broadcast sync --config sync.yaml --ignore-rate-limit-preflight --confirm-scope 12
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--confirm-scope` | _(unset)_ | Confirm a large sync (>1 group or >5 repos) by stating the exact number of repositories it will write to; required (matching the resolved repo count) in non-interactive contexts |
+
+<br/>
+
 ### Install [MAGE-X](https://github.com/mrz1836/mage-x) build tool
 Want to contribute to go-broadcast? Use MAGE-X for building, testing, linting, and more.
 
@@ -893,6 +935,7 @@ go-broadcast sync --groups "default" --config sync.yaml             # Sync by gr
 go-broadcast sync --groups "core,security" --config sync.yaml       # Sync multiple groups
 go-broadcast sync --skip-groups "experimental" --config sync.yaml   # Skip specific groups
 go-broadcast sync --groups "core" org/repo1 --config sync.yaml      # Combine with target filtering
+go-broadcast sync --groups "core,security" --confirm-scope 12 --config sync.yaml  # Confirm a large sync (>1 group or >5 repos) by stating the repo count
 
 # Automerge configuration
 go-broadcast sync --automerge --config sync.yaml                    # Add automerge labels to created PRs

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/firebase/genkit/go v1.9.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/magefile/mage v1.17.2
+	github.com/mattn/go-isatty v0.0.22
 	github.com/openai/openai-go v1.12.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sirupsen/logrus v1.9.4
@@ -48,7 +49,6 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mailru/easyjson v0.9.2 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
-	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mbleigh/raymond v0.0.0-20250414171441-6b3a58ab9e0a // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/internal/cli/cancel_test.go
+++ b/internal/cli/cancel_test.go
@@ -1656,6 +1656,89 @@ func TestPerformCancelWithDiscoverer_GroupFiltering(t *testing.T) {
 	}
 }
 
+// TestPerformCancelWithDiscoverer_SC7_ScopeConsistency is the SC-7 audit
+// regression: cancel must honor the same multi-group scoping semantics as the
+// fixed sync engine's ResolveScope. Group/skip filters are applied via
+// FilterConfigByGroups *before* state discovery (so cancel can never discover or
+// touch more groups than requested), and an explicit target arg narrows the
+// result to exactly that repository. This mirrors ResolveScope's "resolve group
+// scope up front, then narrow to the matching targets" model. Cancel resolves
+// group scope before discovery and target scope after (via filterTargets), which
+// is equivalent for a close-only command and cannot blast more than requested.
+func TestPerformCancelWithDiscoverer_SC7_ScopeConsistency(t *testing.T) {
+	// Multi-group config (3 groups); the target arg belongs to the last group,
+	// proving the fix is not accidentally honoring only the first group.
+	cfg := &config.Config{
+		Version: 1,
+		Groups: []config.Group{
+			{
+				ID:      "core",
+				Name:    "Core Group",
+				Source:  config.SourceConfig{Repo: "org/template", Branch: "main"},
+				Targets: []config.TargetConfig{{Repo: "org/group1-target1"}, {Repo: "org/group1-target2"}},
+			},
+			{
+				ID:      "security",
+				Name:    "Security Group",
+				Source:  config.SourceConfig{Repo: "org/template", Branch: "main"},
+				Targets: []config.TargetConfig{{Repo: "org/group2-target1"}},
+			},
+			{
+				ID:      "vendor-go",
+				Name:    "Vendor Go",
+				Source:  config.SourceConfig{Repo: "acme/template", Branch: "development"},
+				Targets: []config.TargetConfig{{Repo: "org/group4-target1"}},
+			},
+		},
+	}
+
+	// Ensure dry run is off (thread-safe).
+	originalFlags := GetGlobalFlags()
+	SetFlags(&Flags{ConfigFile: originalFlags.ConfigFile, DryRun: false, LogLevel: originalFlags.LogLevel})
+	defer func() { SetFlags(originalFlags) }()
+
+	// Scope to a single group via --groups, mirroring a one-group-at-a-time run.
+	originalGroupFilter := getCancelGroupFilter()
+	originalSkipGroups := getCancelSkipGroups()
+	defer func() {
+		setCancelGroupFilter(originalGroupFilter)
+		setCancelSkipGroups(originalSkipGroups)
+	}()
+	setCancelGroupFilter([]string{"vendor-go"})
+	setCancelSkipGroups(nil)
+
+	mockClient := &gh.MockClient{}
+	mockClient.On("ClosePR", mock.Anything, "org/group4-target1", 430, mock.AnythingOfType("string")).Return(nil)
+	mockClient.On("DeleteBranch", mock.Anything, "org/group4-target1", "chore/sync-files-vendor-go-20250112-145757-561a06e").Return(nil)
+
+	// Scope-before-discovery: the discoverer must receive ONLY the filtered group,
+	// so cancel cannot discover state for groups outside the requested scope.
+	mockDiscoverer := &state.MockDiscoverer{}
+	mockDiscoverer.On("DiscoverState", mock.Anything, mock.MatchedBy(func(c *config.Config) bool {
+		return len(c.Groups) == 1 && c.Groups[0].ID == "vendor-go"
+	})).Return(createMultiGroupState(), nil)
+
+	// Target arg further narrows to a single repo within the already-scoped group.
+	summary, err := performCancelWithDiscoverer(
+		context.Background(),
+		cfg,
+		[]string{"org/group4-target1"},
+		mockClient,
+		mockDiscoverer,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, 1, summary.TotalTargets, "multi-group config + one target arg must resolve to exactly one repo")
+	require.Len(t, summary.Results, 1)
+	assert.Equal(t, "org/group4-target1", summary.Results[0].Repository)
+	assert.Equal(t, 1, summary.PRsClosed)
+	assert.Equal(t, 0, summary.Errors)
+
+	mockClient.AssertExpectations(t)
+	mockDiscoverer.AssertExpectations(t)
+}
+
 func TestPerformCancelWithDiscoverer_EmptyGroupFilter(t *testing.T) {
 	// Test that when no groups match the filter, we get an empty summary without errors
 	cfg := &config.Config{

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -303,7 +303,20 @@ Configuration Source:
 Group Filtering:
   Use --groups to sync only specific groups (by name or ID).
   Use --skip-groups to exclude specific groups from sync.
-  When both are specified, skip-groups takes precedence.`,
+  When both are specified, skip-groups takes precedence.
+
+Scope is resolved up front, so a target argument or --groups/--skip-groups always
+narrows the run to exactly what you named — even in a multi-group config. The
+resolved scope (groups, repos, repo count) is printed before any write.
+
+Blast-radius confirmation guard:
+  A large sync — more than 1 group OR more than 5 repositories in the resolved
+  scope — must be confirmed before any write. On an interactive terminal you are
+  prompted to type the resolved repository count. In non-interactive contexts
+  (agents, CI, no TTY) the sync hard-refuses unless --confirm-scope=<N> is passed
+  with N equal to the resolved repository count. N is always the repository count,
+  never the group count, so --confirm-scope=1 cannot pass a 6-repo single-group
+  sync. --ignore-rate-limit-preflight does NOT bypass this guard.`,
 	Example: `  # Basic operations
   go-broadcast sync                        # Sync all targets from config
   go-broadcast sync --config sync.yaml     # Use specific config file
@@ -318,6 +331,9 @@ Group Filtering:
   go-broadcast sync --groups "core,security"       # Sync only core and security groups
   go-broadcast sync --skip-groups "experimental"   # Sync all except experimental group
   go-broadcast sync --groups core org/repo1        # Sync specific target in core group
+
+  # Large sync confirmation (>1 group or >5 repos)
+  go-broadcast sync --groups "core,security" --confirm-scope 12  # Confirm by stating the resolved repo count (required when non-interactive)
 
   # Debugging and troubleshooting
   go-broadcast sync --log-level debug      # Enable debug logging

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -142,6 +142,7 @@ const (
 	flagRateLimitMarginPercent    = "rate-limit-margin-percent"
 	flagRateLimitSecondaryReserve = "rate-limit-secondary-reserve"
 	flagRateLimitFailClosed       = "rate-limit-fail-closed"
+	flagConfirmScope              = "confirm-scope"
 )
 
 //nolint:gochecknoglobals // Package-level variables for CLI flags
@@ -161,6 +162,11 @@ var (
 	rateLimitMarginPercent    = config.DefaultRateLimitPrimaryMarginPercent
 	rateLimitSecondaryReserve = config.DefaultRateLimitSecondaryReserve
 	rateLimitFailClosed       bool
+
+	// confirmScope carries the --confirm-scope=<N> blast-radius opt-in. It is only
+	// applied to Options when explicitly set (see currentRateLimitOverrides /
+	// Changed()); N must equal the resolved repository count to proceed.
+	confirmScope int
 
 	// syncFlagSet is the sync command's flag set, captured in init() so that
 	// override detection (Changed()) does not statically reference the syncCmd
@@ -207,6 +213,10 @@ type rateLimitPreflightOverrides struct {
 	margin     *int
 	reserve    *int
 	failClosed *bool
+
+	// confirmScope is the --confirm-scope=<N> blast-radius opt-in. nil means the
+	// flag was not set; non-nil carries the operator-confirmed repo count.
+	confirmScope *int
 }
 
 // mergeRateLimitPreflight applies the resolved rate-limit preflight settings to
@@ -234,7 +244,8 @@ func mergeRateLimitPreflight(opts *sync.Options, cfg *config.Config, ov rateLimi
 		WithRateLimitPreflight(enabled).
 		WithRateLimitMargins(margin, reserve).
 		WithRateLimitFailClosed(failClosed).
-		WithIgnoreRateLimitPreflight(ov.ignore)
+		WithIgnoreRateLimitPreflight(ov.ignore).
+		WithConfirmScope(ov.confirmScope)
 }
 
 // currentRateLimitOverrides reads the sync command's CLI flags and returns the
@@ -267,6 +278,10 @@ func currentRateLimitOverrides() rateLimitPreflightOverrides {
 	if flags.Changed(flagRateLimitFailClosed) {
 		v := rateLimitFailClosed
 		ov.failClosed = &v
+	}
+	if flags.Changed(flagConfirmScope) {
+		v := confirmScope
+		ov.confirmScope = &v
 	}
 
 	return ov
@@ -335,6 +350,12 @@ func init() {
 	syncCmd.Flags().IntVar(&rateLimitMarginPercent, flagRateLimitMarginPercent, config.DefaultRateLimitPrimaryMarginPercent, "Percent of the primary rate-limit budget to keep as headroom")
 	syncCmd.Flags().IntVar(&rateLimitSecondaryReserve, flagRateLimitSecondaryReserve, config.DefaultRateLimitSecondaryReserve, "Number of the 80/min secondary content-write slots to keep in reserve")
 	syncCmd.Flags().BoolVar(&rateLimitFailClosed, flagRateLimitFailClosed, false, "Halt the sync when the rate-limit probe is unavailable (default fails open)")
+
+	// Blast-radius confirmation guard. A resolved scope crossing >1 group OR >5
+	// repos must be confirmed with the resolved repo count before any write. This
+	// is a separate gate from the rate-limit preflight; --ignore-rate-limit-preflight
+	// does NOT bypass it.
+	syncCmd.Flags().IntVar(&confirmScope, flagConfirmScope, 0, "Confirm a large sync (>1 group or >5 repos) by stating the exact number of repositories it will write to")
 
 	// Capture the flag set for override detection without statically referencing
 	// syncCmd from the engine-builder call graph (avoids an init cycle).

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -34,6 +34,7 @@ type Engine struct {
 	transform      transform.Chain
 	options        *Options
 	logger         *logrus.Logger
+	scopeConfirmer ScopeConfirmer // Blast-radius interactive confirmer (injectable for tests)
 
 	// AI text generation (optional, nil when disabled)
 	prGenerator     *ai.PRBodyGenerator
@@ -62,13 +63,14 @@ func NewEngine(
 	}
 
 	e := &Engine{
-		config:    cfg,
-		gh:        ghClient,
-		git:       gitClient,
-		state:     stateDiscoverer,
-		transform: transformChain,
-		options:   opts,
-		logger:    logrus.StandardLogger(),
+		config:         cfg,
+		gh:             ghClient,
+		git:            gitClient,
+		state:          stateDiscoverer,
+		transform:      transformChain,
+		options:        opts,
+		logger:         logrus.StandardLogger(),
+		scopeConfirmer: newTerminalScopeConfirmer(),
 	}
 
 	// Initialize AI components (non-fatal if it fails)
@@ -116,6 +118,12 @@ func (e *Engine) SetCurrentGroup(group *config.Group) {
 	e.currentGroupMu.Lock()
 	defer e.currentGroupMu.Unlock()
 	e.currentGroup = group
+}
+
+// SetScopeConfirmer sets a custom blast-radius scope confirmer. Tests inject a
+// non-TTY fake so the guard's interactive branch is exercised without a terminal.
+func (e *Engine) SetScopeConfirmer(c ScopeConfirmer) {
+	e.scopeConfirmer = c
 }
 
 // SetSyncMetricsRecorder sets the sync metrics recorder for this engine
@@ -275,6 +283,16 @@ func (e *Engine) Sync(ctx context.Context, targetFilter []string) error {
 		"repo_count":  scope.RepoCount,
 	}).Info("Processing resolved sync scope")
 
+	// Blast-radius confirmation guard (SC-3/SC-4). This is a SEPARATE gate from
+	// the rate-limit preflight, evaluated first and independently: it never reads
+	// IgnoreRateLimitPreflight, so disabling the rate-limit gate can never re-open
+	// the scope hole that disabling the rate-limit gate would otherwise re-open. On
+	// a guarded scope without a matching confirmation it returns
+	// ErrScopeConfirmationRequired before any write happens.
+	if err := e.runBlastRadiusGuard(scope); err != nil {
+		return err
+	}
+
 	// Rate-limit preflight gate (whole-run, before any write). This runs once at
 	// the single chokepoint both the single-group and multi-group paths flow
 	// through, so the "all-or-nothing, no partial state" guarantee holds for every
@@ -301,6 +319,56 @@ func (e *Engine) Sync(ctx context.Context, targetFilter []string) error {
 
 	// Execute the single group sync
 	return e.executeSingleGroup(ctx, group, nil)
+}
+
+// runBlastRadiusGuard evaluates the blast-radius confirmation guard for the
+// resolved scope (SC-3/SC-4). It is a separate gate from the rate-limit
+// preflight and never reads IgnoreRateLimitPreflight by construction.
+//
+// Behavior:
+//   - Scope below the thresholds → no-op (proceed).
+//   - --confirm-scope=<N> matching the resolved repo count → proceed.
+//   - Interactive TTY with no matching flag → prompt for the exact resolved repo
+//     count; proceed only when the typed value matches.
+//   - Non-interactive with no matching flag → hard refuse
+//     (ErrScopeConfirmationRequired, zero writes).
+func (e *Engine) runBlastRadiusGuard(scope ResolvedScope) error {
+	interactive := false
+	if e.scopeConfirmer != nil {
+		interactive = e.scopeConfirmer.Interactive()
+	}
+
+	log := e.logger.WithField("component", "blast_radius_guard")
+
+	decision := decideScopeGuard(scope, e.options.ConfirmScope, interactive)
+	if decision.Proceed {
+		return nil
+	}
+
+	if decision.NeedPrompt {
+		typed, err := e.scopeConfirmer.Prompt(scope)
+		if err != nil {
+			msg := fmt.Sprintf("could not read scope confirmation: %v", err)
+			output.Error(msg)
+			log.WithError(err).Error("Blast-radius guard prompt failed; refusing the sync")
+			return fmt.Errorf("%w: %s", ErrScopeConfirmationRequired, msg)
+		}
+		if typed == scope.RepoCount {
+			log.WithField("repo_count", scope.RepoCount).Info("Blast-radius scope confirmed interactively")
+			return nil
+		}
+		msg := fmt.Sprintf(
+			"scope confirmation mismatch: expected the resolved repo count %d, got %d; refusing the sync",
+			scope.RepoCount, typed,
+		)
+		output.Error(msg)
+		log.WithFields(logrus.Fields{"expected": scope.RepoCount, "got": typed}).Error("Blast-radius guard refused the sync")
+		return fmt.Errorf("%w: %s", ErrScopeConfirmationRequired, msg)
+	}
+
+	output.Error(decision.Reason)
+	log.WithField("reason", decision.Reason).Error("Blast-radius guard refused the sync before any write")
+	return fmt.Errorf("%w: %s", ErrScopeConfirmationRequired, decision.Reason)
 }
 
 // runRateLimitPreflight runs the whole-run rate-limit gate before any sync write.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -242,14 +242,38 @@ func (e *Engine) Sync(ctx context.Context, targetFilter []string) error {
 		log.Warn("DRY-RUN MODE: No changes will be made")
 	}
 
-	// Get groups using compatibility layer
-	groups := e.config.Groups
-	if len(groups) == 0 {
+	if len(e.config.Groups) == 0 {
 		log.Info("No groups found in configuration")
 		return nil
 	}
 
-	log.WithField("group_count", len(groups)).Info("Processing sync groups")
+	// Resolve the full scope up front — group/skip/enabled filtering plus the
+	// target-filter repo narrowing — before the single- vs multi-group branch.
+	// This makes the target/group filters authoritative in every config shape
+	// (the multi-group path previously ignored targetFilter entirely). SC-1/SC-2.
+	scope, err := ResolveScope(e.config, e.options, targetFilter)
+	if err != nil {
+		return err
+	}
+	if scope.RepoCount == 0 {
+		log.Info("Nothing to sync after applying scope filters")
+		return nil
+	}
+
+	// Scope this run's config to exactly what will be written, so state
+	// discovery, the rate-limit estimate, and the execution paths all operate on
+	// the resolved scope (mirrors cancel's filter-before-discovery and the
+	// orchestrator's per-group config swap).
+	e.config = scope.Config
+
+	// Surface the resolved scope before any write happens, on every invocation
+	// (not only --dry-run), so the blast radius is always visible. SC-5.
+	output.Info(scope.Summary())
+
+	log.WithFields(logrus.Fields{
+		"group_count": scope.GroupCount,
+		"repo_count":  scope.RepoCount,
+	}).Info("Processing resolved sync scope")
 
 	// Rate-limit preflight gate (whole-run, before any write). This runs once at
 	// the single chokepoint both the single-group and multi-group paths flow
@@ -260,20 +284,23 @@ func (e *Engine) Sync(ctx context.Context, targetFilter []string) error {
 		return err
 	}
 
-	// Check if we have multiple groups - use orchestrator if so
+	// Branch on the resolved group count. Targets are already narrowed in the
+	// scoped config, so both paths run with no further target filtering.
+	groups := scope.Config.Groups
 	if len(groups) > 1 {
-		// Use the orchestrator for multi-group execution
+		// Use the orchestrator for multi-group execution.
 		orchestrator := NewGroupOrchestrator(e.config, e, e.logger)
 		return orchestrator.ExecuteGroups(ctx, groups)
 	}
 
-	// Single group - execute directly
+	// Single group - execute directly. The group's targets are pre-narrowed, so
+	// a nil target filter is correct here.
 	group := groups[0]
 	e.SetCurrentGroup(&group) // Set current group for RepositorySync to use
 	log.WithField("group_name", group.Name).Info("Processing single group")
 
 	// Execute the single group sync
-	return e.executeSingleGroup(ctx, group, targetFilter)
+	return e.executeSingleGroup(ctx, group, nil)
 }
 
 // runRateLimitPreflight runs the whole-run rate-limit gate before any sync write.

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -288,7 +288,9 @@ func TestEngineSync(t *testing.T) {
 			},
 		}
 
-		stateDiscoverer.On("DiscoverState", mock.Anything, cfg).Return(currentState, nil)
+		// Scope is now resolved before state discovery, so the engine discovers
+		// state for the narrowed (single-target) config rather than the original.
+		stateDiscoverer.On("DiscoverState", mock.Anything, mock.Anything).Return(currentState, nil)
 
 		engine := NewEngine(context.Background(), cfg, ghClient, gitClient, stateDiscoverer, transformChain, nil)
 
@@ -328,7 +330,9 @@ func TestEngineSync(t *testing.T) {
 			Targets: map[string]*state.TargetState{},
 		}
 
-		stateDiscoverer.On("DiscoverState", mock.Anything, cfg).Return(currentState, nil)
+		// Scope resolution now rejects a non-matching target filter up front, so
+		// state discovery is never reached for an invalid target filter.
+		stateDiscoverer.On("DiscoverState", mock.Anything, mock.Anything).Return(currentState, nil).Maybe()
 
 		engine := NewEngine(context.Background(), cfg, ghClient, gitClient, stateDiscoverer, transformChain, nil)
 

--- a/internal/sync/estimate.go
+++ b/internal/sync/estimate.go
@@ -84,17 +84,17 @@ func EstimateRun(cfg *config.Config, options *Options) RunEstimate {
 	}
 }
 
-// resolveEstimateGroups returns the groups that would actually be synced,
-// mirroring GroupOrchestrator.filterGroupsByOptions followed by
-// filterEnabledGroups (same order ExecuteGroups applies). Kept as a pure,
-// logger-free helper so the estimate has no I/O dependency.
+// resolveEstimateGroups returns the groups that would actually be synced. It
+// derives the group set from ResolveScope (with no target filter) so the
+// rate-limit estimate and the resolved sync scope can never drift apart. The
+// underlying group/skip/enabled filtering still flows through the same pure,
+// logger-free helpers, so the estimate has no I/O dependency.
 func resolveEstimateGroups(cfg *config.Config, options *Options) []config.Group {
-	if cfg == nil {
+	scope, err := ResolveScope(cfg, options, nil)
+	if err != nil || scope.Config == nil {
 		return nil
 	}
-
-	groups := filterEstimateGroupsByOptions(cfg.Groups, options)
-	return filterEstimateEnabledGroups(groups)
+	return scope.Config.Groups
 }
 
 // filterEstimateGroupsByOptions mirrors GroupOrchestrator.filterGroupsByOptions:

--- a/internal/sync/options.go
+++ b/internal/sync/options.go
@@ -69,6 +69,12 @@ type Options struct {
 	// RateLimitFailClosed halts the sync when the rate-limit probe is unavailable
 	// instead of failing open with a warning
 	RateLimitFailClosed bool
+
+	// ConfirmScope, when non-nil, is the operator-supplied resolved repository
+	// count used to satisfy the blast-radius guard (the --confirm-scope=<N> flag).
+	// nil means the flag was not provided. The value must equal the resolved repo
+	// count; a boolean always-pass token is intentionally not accepted (Q7=A).
+	ConfirmScope *int
 }
 
 // DefaultOptions returns the default sync options
@@ -185,5 +191,13 @@ func (o *Options) WithRateLimitFailClosed(failClosed bool) *Options {
 // the preflight gate would halt
 func (o *Options) WithIgnoreRateLimitPreflight(ignore bool) *Options {
 	o.IgnoreRateLimitPreflight = ignore
+	return o
+}
+
+// WithConfirmScope sets the operator-supplied resolved repository count used to
+// satisfy the blast-radius guard. Pass nil to leave it unset (the flag was not
+// provided), or a pointer to the confirmed repo count.
+func (o *Options) WithConfirmScope(n *int) *Options {
+	o.ConfirmScope = n
 	return o
 }

--- a/internal/sync/orchestrator_integration_test.go
+++ b/internal/sync/orchestrator_integration_test.go
@@ -188,6 +188,10 @@ func TestOrchestrator_MultiGroupSync(t *testing.T) {
 	engine := NewEngine(context.Background(), cfg, ghClient, gitClient, stateDiscoverer, transformChain, DefaultOptions())
 	engine.SetLogger(logrus.New())
 
+	// This multi-group scope (2 groups / 3 repos) trips the blast-radius guard,
+	// so confirm it with the resolved repo count to exercise the confirmed path.
+	engine.SetScopeConfirmer(&fakeConfirmer{interactive: true, reply: 3})
+
 	// Execute the sync
 	err := engine.Sync(context.Background(), []string{})
 

--- a/internal/sync/scope.go
+++ b/internal/sync/scope.go
@@ -1,0 +1,175 @@
+package sync
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mrz1836/go-broadcast/internal/config"
+	appErrors "github.com/mrz1836/go-broadcast/internal/errors"
+)
+
+// ResolvedScope is the single, up-front resolution of what a sync invocation
+// will actually touch. It is produced by ResolveScope before the single- vs
+// multi-group branch in Engine.Sync, so the target/group filters are honored in
+// every config shape (previously the multi-group path silently ignored them).
+//
+// Config is an executable, scoped config: its Groups have been filtered by the
+// group/skip/enabled rules and, when a target filter is supplied, each group's
+// Targets are narrowed to the matching repositories. The counts and the flat
+// Groups / Repos lists describe the resolved blast radius and feed both the
+// pre-write summary (SC-5) and the blast-radius guard (added in a later phase).
+type ResolvedScope struct {
+	// Config is the scoped configuration to execute. When no filtering applies
+	// it is the original config pointer; otherwise it is a narrowed copy.
+	Config *config.Config
+
+	// Groups is the list of in-scope group labels (name, falling back to ID).
+	Groups []string
+
+	// Repos is the flat list of in-scope target repositories across all groups.
+	Repos []string
+
+	// GroupCount is the number of in-scope groups.
+	GroupCount int
+
+	// RepoCount is the total number of in-scope target repositories (the
+	// resolved blast radius / total repos that may be written).
+	RepoCount int
+}
+
+// ResolveScope resolves the set of groups and target repositories a sync
+// invocation will actually run, mirroring cli.FilterConfigByGroups (group /
+// skip / enabled filtering) and additionally narrowing each group's targets to
+// targetFilter when one is provided.
+//
+// Resolution order, matching the orchestrator and the rate-limit estimate:
+//  1. options.SkipGroups removes matching groups (by name or ID).
+//  2. options.GroupFilter, when set, retains only matching groups.
+//  3. Disabled groups (Enabled explicitly false) are removed.
+//  4. targetFilter, when set, keeps only targets whose Repo is listed; groups
+//     left with zero matching targets are dropped.
+//
+// When targetFilter is non-empty and no target repository matches it across the
+// surviving groups, it returns appErrors.ErrNoMatchingTargets, preserving the
+// engine's prior behavior. When nothing is filtered away (no explicit group /
+// skip / target filters and every group is enabled) the original config pointer
+// is preserved so callers relying on pointer identity (e.g. state discovery)
+// see the unchanged config.
+func ResolveScope(cfg *config.Config, options *Options, targetFilter []string) (ResolvedScope, error) {
+	if cfg == nil {
+		return ResolvedScope{}, nil
+	}
+
+	// Steps 1-3: group/skip/enabled filtering (reuses the audited estimate
+	// helpers so the resolved scope and the rate-limit estimate cannot drift).
+	// References options.GroupFilter / options.SkipGroups for the change check.
+	filtered := filterEstimateGroupsByOptions(cfg.Groups, options)
+	filtered = filterEstimateEnabledGroups(filtered)
+
+	// Step 4: narrow each surviving group's targets to the target filter.
+	narrowed := make([]config.Group, 0, len(filtered))
+	matchedAnyTarget := false
+	for _, group := range filtered {
+		if len(targetFilter) == 0 {
+			narrowed = append(narrowed, group)
+			continue
+		}
+
+		keptTargets := make([]config.TargetConfig, 0, len(group.Targets))
+		for _, target := range group.Targets {
+			if containsRepo(targetFilter, target.Repo) {
+				keptTargets = append(keptTargets, target)
+			}
+		}
+		if len(keptTargets) == 0 {
+			continue // group has no targets matching the filter; drop it
+		}
+
+		matchedAnyTarget = true
+		scopedGroup := group
+		scopedGroup.Targets = keptTargets
+		narrowed = append(narrowed, scopedGroup)
+	}
+
+	if len(targetFilter) > 0 && !matchedAnyTarget {
+		return ResolvedScope{}, fmt.Errorf("%w: %v", appErrors.ErrNoMatchingTargets, targetFilter)
+	}
+
+	// Preserve the original config pointer when nothing was filtered away, so
+	// state discovery and other consumers keying off the config pointer are
+	// unaffected by the resolution step.
+	filtersProvided := options != nil && (len(options.GroupFilter) > 0 || len(options.SkipGroups) > 0)
+	var scopeConfig *config.Config
+	if !filtersProvided && len(targetFilter) == 0 && len(narrowed) == len(cfg.Groups) {
+		scopeConfig = cfg
+	} else {
+		scopeConfig = cloneConfigWithGroups(cfg, narrowed)
+	}
+
+	groups := make([]string, 0, len(narrowed))
+	repos := make([]string, 0)
+	for _, group := range narrowed {
+		groups = append(groups, groupLabel(group))
+		for _, target := range group.Targets {
+			repos = append(repos, target.Repo)
+		}
+	}
+
+	return ResolvedScope{
+		Config:     scopeConfig,
+		Groups:     groups,
+		Repos:      repos,
+		GroupCount: len(narrowed),
+		RepoCount:  len(repos),
+	}, nil
+}
+
+// Summary returns a human-readable description of the resolved scope. It is
+// printed before any write on every invocation (SC-5) so an operator always
+// sees exactly which groups and repositories a sync will touch.
+func (s ResolvedScope) Summary() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Resolved sync scope: %d group(s), %d repo(s)\n", s.GroupCount, s.RepoCount)
+
+	if len(s.Groups) > 0 {
+		fmt.Fprintf(&b, "  Groups: %s\n", strings.Join(s.Groups, ", "))
+	}
+	if len(s.Repos) > 0 {
+		fmt.Fprintf(&b, "  Repos: %s\n", strings.Join(s.Repos, ", "))
+	}
+
+	// One pull-request/content write per target (mirrors the preflight's
+	// contentWritesPerTarget), so the estimated writes equal the repo count.
+	fmt.Fprintf(&b, "  Estimated PRs/writes: %d", s.RepoCount)
+
+	return b.String()
+}
+
+// cloneConfigWithGroups returns a shallow copy of cfg with its Groups replaced
+// by the provided (filtered/narrowed) groups, mirroring the field set copied by
+// cli.FilterConfigByGroups so the scoped config remains fully usable.
+func cloneConfigWithGroups(cfg *config.Config, groups []config.Group) *config.Config {
+	scoped := *cfg
+	scoped.Groups = groups
+	return &scoped
+}
+
+// groupLabel returns a display label for a group, preferring its friendly name
+// and falling back to its ID.
+func groupLabel(group config.Group) string {
+	if group.Name != "" {
+		return group.Name
+	}
+	return group.ID
+}
+
+// containsRepo reports whether repo is present in the filter list (exact match).
+func containsRepo(filter []string, repo string) bool {
+	for _, f := range filter {
+		if f == repo {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sync/scope_guard.go
+++ b/internal/sync/scope_guard.go
@@ -1,0 +1,179 @@
+package sync
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+)
+
+// Blast-radius guard thresholds. A resolved sync scope that crosses either
+// threshold trips the confirmation guard (SC-3): more than one group, OR more
+// than five repositories in the resolved scope. The repo threshold closes the
+// single-group-many-repos hole — a config where dozens of repos live in one
+// group could otherwise blast widely without ever crossing the ">1 group" line.
+const (
+	// BlastRadiusMaxGroups is the largest group count that passes the guard
+	// silently. The operating rule is one group at a time, so any scope with more
+	// than one group always requires explicit confirmation.
+	BlastRadiusMaxGroups = 1
+
+	// BlastRadiusMaxRepos is the largest repository count that passes the guard
+	// silently. A sync touching more than this many repos requires explicit
+	// confirmation even when it stays within a single group.
+	BlastRadiusMaxRepos = 5
+)
+
+// ErrScopeConfirmationRequired is the sentinel returned when a sync's resolved
+// scope trips the blast-radius guard and the operator has not explicitly
+// confirmed the resolved repository count. It is matchable with errors.Is.
+//
+// Non-interactive contexts (agents, CI, no TTY) return this unless a matching
+// --confirm-scope=<N> is supplied (default-deny); interactive contexts return it
+// when the typed value does not match the resolved repo count.
+var ErrScopeConfirmationRequired = errors.New("blast-radius scope confirmation required")
+
+// GuardTriggered reports whether the resolved scope crosses the blast-radius
+// thresholds and therefore requires explicit confirmation before any write.
+func (s ResolvedScope) GuardTriggered() bool {
+	return s.GroupCount > BlastRadiusMaxGroups || s.RepoCount > BlastRadiusMaxRepos
+}
+
+// ScopeGuardDecision is the pure outcome of the blast-radius guard for a
+// resolved scope and the supplied confirmation state. It carries no I/O.
+type ScopeGuardDecision struct {
+	// Proceed reports whether the sync may proceed without (further) prompting.
+	Proceed bool
+
+	// NeedPrompt reports that an interactive type-the-count prompt is required
+	// before proceeding. Only set in interactive contexts when no matching
+	// --confirm-scope was supplied.
+	NeedPrompt bool
+
+	// ExpectedN is the resolved repository count the operator must confirm. It is
+	// always the repo count (never trivially 1 on a guarded single-group sync).
+	ExpectedN int
+
+	// Reason explains a refusal. Empty when Proceed or NeedPrompt is set.
+	Reason string
+}
+
+// decideScopeGuard is the pure blast-radius decision. It has no TTY or stdin
+// dependency, so every branch is unit-testable without a terminal.
+//
+// The confirmation token is always the resolved repository count (the real blast
+// radius), so a guard tripped by the repo threshold inside a single group can
+// never be satisfied with --confirm-scope=1.
+//
+// Branches:
+//   - scope not triggered                       → Proceed.
+//   - confirmScope supplied and == RepoCount     → Proceed.
+//   - confirmScope supplied and != RepoCount     → refuse (mismatch).
+//   - interactive (no confirmScope)              → NeedPrompt (ExpectedN = RepoCount).
+//   - non-interactive (no confirmScope)          → refuse (default-deny).
+func decideScopeGuard(scope ResolvedScope, confirmScope *int, interactive bool) ScopeGuardDecision {
+	if !scope.GuardTriggered() {
+		return ScopeGuardDecision{Proceed: true}
+	}
+
+	expected := scope.RepoCount
+
+	// Explicit count-bearing opt-in works in any context (TTY or not).
+	if confirmScope != nil {
+		if *confirmScope == expected {
+			return ScopeGuardDecision{Proceed: true, ExpectedN: expected}
+		}
+		return ScopeGuardDecision{
+			ExpectedN: expected,
+			Reason: fmt.Sprintf(
+				"--confirm-scope=%d does not match the resolved repo count %d (blast radius: %d repo(s) across %d group(s))",
+				*confirmScope, expected, scope.RepoCount, scope.GroupCount,
+			),
+		}
+	}
+
+	// Interactive: ask the operator to type the exact resolved repo count.
+	if interactive {
+		return ScopeGuardDecision{NeedPrompt: true, ExpectedN: expected}
+	}
+
+	// Non-interactive default-deny: an agent/CI literally cannot trigger a
+	// guarded sync without stating the real blast radius.
+	return ScopeGuardDecision{
+		ExpectedN: expected,
+		Reason: fmt.Sprintf(
+			"refusing to sync %d repo(s) across %d group(s) without confirmation; re-run with --confirm-scope=%d to proceed",
+			scope.RepoCount, scope.GroupCount, expected,
+		),
+	}
+}
+
+// ScopeConfirmer abstracts interactive confirmation of a guarded blast radius so
+// TTY detection and stdin reads stay out of the pure decision logic and tests
+// can inject a fake.
+type ScopeConfirmer interface {
+	// Interactive reports whether an interactive confirmation prompt is possible
+	// (a real TTY is attached).
+	Interactive() bool
+
+	// Prompt displays the resolved scope and reads the operator's typed
+	// confirmation, returning the integer they entered.
+	Prompt(scope ResolvedScope) (int, error)
+}
+
+// terminalScopeConfirmer is the default ScopeConfirmer. It detects a TTY on its
+// input stream and reads a single line as the confirmation count.
+type terminalScopeConfirmer struct {
+	in  *os.File
+	out io.Writer
+}
+
+// newTerminalScopeConfirmer returns the default confirmer wired to stdin/stderr.
+func newTerminalScopeConfirmer() *terminalScopeConfirmer {
+	return &terminalScopeConfirmer{in: os.Stdin, out: os.Stderr}
+}
+
+// Interactive reports whether stdin is attached to a real terminal.
+func (c *terminalScopeConfirmer) Interactive() bool {
+	if c.in == nil {
+		return false
+	}
+	fd := c.in.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+// Prompt lists every in-scope group and repository, then reads one line of input
+// and parses it as the confirmation count. Non-numeric input parses to 0, which
+// never equals a guarded scope's repo count, so the caller fails closed.
+func (c *terminalScopeConfirmer) Prompt(scope ResolvedScope) (int, error) {
+	w := c.out
+	if w == nil {
+		w = os.Stderr
+	}
+
+	_, _ = fmt.Fprintln(w, scope.Summary())
+	_, _ = fmt.Fprintf(w, "\nThis sync will write to %d repositor(ies) across %d group(s):\n", scope.RepoCount, scope.GroupCount)
+	if len(scope.Groups) > 0 {
+		_, _ = fmt.Fprintf(w, "  Groups: %s\n", strings.Join(scope.Groups, ", "))
+	}
+	for _, repo := range scope.Repos {
+		_, _ = fmt.Fprintf(w, "  - %s\n", repo)
+	}
+	_, _ = fmt.Fprintf(w, "\nType the exact number of repositories (%d) to confirm, or anything else to abort: ", scope.RepoCount)
+
+	reader := bufio.NewReader(c.in)
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return 0, err
+	}
+
+	// Non-numeric input parses to 0, which never matches a guarded scope's repo
+	// count, so the caller fails closed.
+	n, _ := strconv.Atoi(strings.TrimSpace(line))
+	return n, nil
+}

--- a/internal/sync/scope_guard_test.go
+++ b/internal/sync/scope_guard_test.go
@@ -1,0 +1,231 @@
+package sync
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testLogger returns a logger that discards output, for guard unit tests.
+func testLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+// scopeWith builds a ResolvedScope with the given group and repo counts (the
+// only fields the guard reads). The Repos slice is populated so Summary/Prompt
+// have something to list.
+func scopeWith(groupCount, repoCount int) ResolvedScope {
+	repos := make([]string, repoCount)
+	for i := range repos {
+		repos[i] = "org/repo"
+	}
+	groups := make([]string, groupCount)
+	for i := range groups {
+		groups[i] = "group"
+	}
+	return ResolvedScope{
+		Groups:     groups,
+		Repos:      repos,
+		GroupCount: groupCount,
+		RepoCount:  repoCount,
+	}
+}
+
+func TestResolvedScope_GuardTriggered(t *testing.T) {
+	tests := []struct {
+		name       string
+		groupCount int
+		repoCount  int
+		want       bool
+	}{
+		{name: "single group single repo passes", groupCount: 1, repoCount: 1, want: false},
+		{name: "single group five repos passes", groupCount: 1, repoCount: 5, want: false},
+		{name: "single group six repos trips", groupCount: 1, repoCount: 6, want: true},
+		{name: "two groups trips", groupCount: 2, repoCount: 2, want: true},
+		{name: "two groups within repo limit still trips on group", groupCount: 2, repoCount: 4, want: true},
+		{name: "zero scope passes", groupCount: 0, repoCount: 0, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, scopeWith(tt.groupCount, tt.repoCount).GuardTriggered())
+		})
+	}
+}
+
+func TestDecideScopeGuard(t *testing.T) {
+	tests := []struct {
+		name         string
+		scope        ResolvedScope
+		confirmScope *int
+		interactive  bool
+		wantProceed  bool
+		wantPrompt   bool
+		wantExpected int
+	}{
+		{
+			name:        "not triggered proceeds without confirmation",
+			scope:       scopeWith(1, 3),
+			wantProceed: true,
+		},
+		{
+			name:         "multi-group non-interactive no flag refuses",
+			scope:        scopeWith(3, 3),
+			interactive:  false,
+			wantProceed:  false,
+			wantExpected: 3,
+		},
+		{
+			name:         "single-group over five repos non-interactive no flag refuses",
+			scope:        scopeWith(1, 6),
+			interactive:  false,
+			wantProceed:  false,
+			wantExpected: 6,
+		},
+		{
+			name:         "matching confirm-scope proceeds",
+			scope:        scopeWith(3, 3),
+			confirmScope: intPtr(3),
+			wantProceed:  true,
+			wantExpected: 3,
+		},
+		{
+			name:         "mismatched confirm-scope refuses",
+			scope:        scopeWith(3, 3),
+			confirmScope: intPtr(2),
+			wantProceed:  false,
+			wantExpected: 3,
+		},
+		{
+			name:         "interactive no flag needs prompt",
+			scope:        scopeWith(3, 3),
+			interactive:  true,
+			wantProceed:  false,
+			wantPrompt:   true,
+			wantExpected: 3,
+		},
+		{
+			name:         "confirm-scope wins over interactive",
+			scope:        scopeWith(3, 3),
+			confirmScope: intPtr(3),
+			interactive:  true,
+			wantProceed:  true,
+			wantExpected: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := decideScopeGuard(tt.scope, tt.confirmScope, tt.interactive)
+			assert.Equal(t, tt.wantProceed, d.Proceed, "Proceed")
+			assert.Equal(t, tt.wantPrompt, d.NeedPrompt, "NeedPrompt")
+			if tt.wantExpected != 0 {
+				assert.Equal(t, tt.wantExpected, d.ExpectedN, "ExpectedN")
+			}
+			if !tt.wantProceed && !tt.wantPrompt {
+				assert.NotEmpty(t, d.Reason, "refusal should carry a reason")
+			}
+		})
+	}
+}
+
+// TestDecideScopeGuard_SingleGroupOverFiveReposTokenIsRepoCount proves AC-6: when
+// the guard trips on the repo threshold inside a single group, the token is the
+// repo count — --confirm-scope=1 (the group count) fails closed and
+// --confirm-scope=<repoCount> proceeds.
+func TestDecideScopeGuard_SingleGroupOverFiveReposTokenIsRepoCount(t *testing.T) {
+	scope := scopeWith(1, 6)
+
+	// --confirm-scope=1 (the group count) must fail closed.
+	d := decideScopeGuard(scope, intPtr(1), false)
+	assert.False(t, d.Proceed, "single-group trip must not accept --confirm-scope=1")
+	assert.NotEmpty(t, d.Reason)
+
+	// --confirm-scope=6 (the repo count) proceeds.
+	d = decideScopeGuard(scope, intPtr(6), false)
+	assert.True(t, d.Proceed, "single-group trip must accept --confirm-scope=<repoCount>")
+}
+
+// fakeConfirmer is an injectable ScopeConfirmer for exercising the interactive
+// branch without a real TTY.
+type fakeConfirmer struct {
+	interactive bool
+	reply       int
+	err         error
+	calls       int
+}
+
+func (f *fakeConfirmer) Interactive() bool { return f.interactive }
+
+func (f *fakeConfirmer) Prompt(_ ResolvedScope) (int, error) {
+	f.calls++
+	return f.reply, f.err
+}
+
+func TestResolvedScope_GuardTriggered_BlastRadiusConstants(t *testing.T) {
+	// The thresholds are the named constants (guards against accidental drift).
+	assert.Equal(t, 1, BlastRadiusMaxGroups)
+	assert.Equal(t, 5, BlastRadiusMaxRepos)
+}
+
+func TestRunBlastRadiusGuard_InteractiveConfirmer(t *testing.T) {
+	scope := scopeWith(3, 3)
+
+	t.Run("typed count matches proceeds", func(t *testing.T) {
+		e := &Engine{options: &Options{}, logger: testLogger(), scopeConfirmer: &fakeConfirmer{interactive: true, reply: 3}}
+		require.NoError(t, e.runBlastRadiusGuard(scope))
+	})
+
+	t.Run("typed count mismatch refuses", func(t *testing.T) {
+		fc := &fakeConfirmer{interactive: true, reply: 2}
+		e := &Engine{options: &Options{}, logger: testLogger(), scopeConfirmer: fc}
+		err := e.runBlastRadiusGuard(scope)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrScopeConfirmationRequired)
+		assert.Equal(t, 1, fc.calls)
+	})
+}
+
+func TestRunBlastRadiusGuard_NonInteractiveDefaultDeny(t *testing.T) {
+	scope := scopeWith(3, 3)
+	e := &Engine{options: &Options{}, logger: testLogger(), scopeConfirmer: &fakeConfirmer{interactive: false}}
+
+	err := e.runBlastRadiusGuard(scope)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrScopeConfirmationRequired)
+}
+
+func TestRunBlastRadiusGuard_ConfirmScopeFlag(t *testing.T) {
+	scope := scopeWith(3, 3)
+
+	t.Run("matching flag proceeds even non-interactive", func(t *testing.T) {
+		e := &Engine{options: &Options{ConfirmScope: intPtr(3)}, logger: testLogger(), scopeConfirmer: &fakeConfirmer{interactive: false}}
+		require.NoError(t, e.runBlastRadiusGuard(scope))
+	})
+
+	t.Run("mismatched flag refuses", func(t *testing.T) {
+		e := &Engine{options: &Options{ConfirmScope: intPtr(2)}, logger: testLogger(), scopeConfirmer: &fakeConfirmer{interactive: false}}
+		err := e.runBlastRadiusGuard(scope)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrScopeConfirmationRequired)
+	})
+}
+
+// TestRunBlastRadiusGuard_IgnoreRateLimitDoesNotBypass proves AC-7: the guard is
+// independent of the rate-limit preflight. Setting IgnoreRateLimitPreflight on a
+// guarded non-interactive scope still refuses without a correct --confirm-scope.
+func TestRunBlastRadiusGuard_IgnoreRateLimitDoesNotBypass(t *testing.T) {
+	scope := scopeWith(3, 3)
+	e := &Engine{
+		options:        &Options{IgnoreRateLimitPreflight: true},
+		logger:         testLogger(),
+		scopeConfirmer: &fakeConfirmer{interactive: false},
+	}
+
+	err := e.runBlastRadiusGuard(scope)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrScopeConfirmationRequired)
+}

--- a/internal/sync/scope_test.go
+++ b/internal/sync/scope_test.go
@@ -1,0 +1,234 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mrz1836/go-broadcast/internal/config"
+	appErrors "github.com/mrz1836/go-broadcast/internal/errors"
+	"github.com/mrz1836/go-broadcast/internal/gh"
+	"github.com/mrz1836/go-broadcast/internal/git"
+	"github.com/mrz1836/go-broadcast/internal/output"
+	"github.com/mrz1836/go-broadcast/internal/state"
+	"github.com/mrz1836/go-broadcast/internal/transform"
+)
+
+// multiGroupConfig builds a config with three groups, each owning a single
+// target repository, used to prove scope resolution narrows correctly.
+func multiGroupConfig() *config.Config {
+	return &config.Config{
+		Version: 1,
+		Groups: []config.Group{
+			{
+				ID:      "core",
+				Name:    "Core",
+				Source:  config.SourceConfig{Repo: "org/template", Branch: "master"},
+				Targets: []config.TargetConfig{{Repo: "org/core-a"}},
+			},
+			{
+				ID:      "libs",
+				Name:    "Libs",
+				Source:  config.SourceConfig{Repo: "org/template", Branch: "master"},
+				Targets: []config.TargetConfig{{Repo: "org/lib-a"}},
+			},
+			{
+				ID:      "apps",
+				Name:    "Apps",
+				Source:  config.SourceConfig{Repo: "org/template", Branch: "master"},
+				Targets: []config.TargetConfig{{Repo: "org/app-a"}},
+			},
+		},
+	}
+}
+
+func TestResolveScope_TargetFilterNarrowsMultiGroup(t *testing.T) {
+	// SC-1: a >=2-group config plus a single target arg resolves to exactly one
+	// group / one repo.
+	cfg := multiGroupConfig()
+
+	scope, err := ResolveScope(cfg, DefaultOptions(), []string{"org/lib-a"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, scope.GroupCount)
+	assert.Equal(t, 1, scope.RepoCount)
+	assert.Equal(t, []string{"org/lib-a"}, scope.Repos)
+	assert.Equal(t, []string{"Libs"}, scope.Groups)
+	require.Len(t, scope.Config.Groups, 1)
+	assert.Equal(t, "libs", scope.Config.Groups[0].ID)
+}
+
+func TestResolveScope_GroupFilterNarrowsMultiGroup(t *testing.T) {
+	// SC-2: --groups core against a multi-group config keeps only core in scope.
+	cfg := multiGroupConfig()
+	opts := DefaultOptions().WithGroupFilter([]string{"core"})
+
+	scope, err := ResolveScope(cfg, opts, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, scope.GroupCount)
+	assert.Equal(t, []string{"Core"}, scope.Groups)
+	assert.Equal(t, []string{"org/core-a"}, scope.Repos)
+}
+
+func TestResolveScope_SkipGroupsPrecedence(t *testing.T) {
+	// SC-2: --skip-groups removes a group even when also named in --groups.
+	cfg := multiGroupConfig()
+	opts := DefaultOptions().
+		WithGroupFilter([]string{"core", "libs"}).
+		WithSkipGroups([]string{"libs"})
+
+	scope, err := ResolveScope(cfg, opts, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, scope.GroupCount)
+	assert.Equal(t, []string{"Core"}, scope.Groups)
+	assert.Equal(t, []string{"org/core-a"}, scope.Repos)
+}
+
+func TestResolveScope_NonMatchingTargetReturnsError(t *testing.T) {
+	// A target filter matching nothing fails closed with ErrNoMatchingTargets.
+	cfg := multiGroupConfig()
+
+	_, err := ResolveScope(cfg, DefaultOptions(), []string{"org/does-not-exist"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, appErrors.ErrNoMatchingTargets)
+}
+
+func TestResolveScope_DisabledGroupsExcluded(t *testing.T) {
+	cfg := multiGroupConfig()
+	disabled := false
+	cfg.Groups[1].Enabled = &disabled // disable "libs"
+
+	scope, err := ResolveScope(cfg, DefaultOptions(), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, scope.GroupCount)
+	assert.Equal(t, []string{"Core", "Apps"}, scope.Groups)
+}
+
+func TestResolveScope_NoFiltersPreservesConfigPointer(t *testing.T) {
+	// With no filters and all groups enabled, the original config pointer is
+	// preserved so downstream consumers keying off it are unaffected.
+	cfg := multiGroupConfig()
+
+	scope, err := ResolveScope(cfg, DefaultOptions(), nil)
+	require.NoError(t, err)
+
+	assert.Same(t, cfg, scope.Config)
+	assert.Equal(t, 3, scope.GroupCount)
+	assert.Equal(t, 3, scope.RepoCount)
+}
+
+func TestResolveScope_NilConfig(t *testing.T) {
+	scope, err := ResolveScope(nil, DefaultOptions(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, scope.RepoCount)
+	assert.Nil(t, scope.Config)
+}
+
+func TestResolvedScope_Summary(t *testing.T) {
+	// SC-5: the summary lists the in-scope groups and the repo count.
+	cfg := multiGroupConfig()
+	scope, err := ResolveScope(cfg, DefaultOptions(), nil)
+	require.NoError(t, err)
+
+	summary := scope.Summary()
+	assert.Contains(t, summary, "3 group(s), 3 repo(s)")
+	assert.Contains(t, summary, "Core")
+	assert.Contains(t, summary, "org/core-a")
+	assert.Contains(t, summary, "Estimated PRs/writes: 3")
+}
+
+func TestResolveEstimateGroups_MatchesResolveScope(t *testing.T) {
+	// The rate-limit estimate derives its groups from ResolveScope, so a
+	// group filter narrows the estimate too (no drift).
+	cfg := multiGroupConfig()
+	opts := DefaultOptions().WithGroupFilter([]string{"core"})
+
+	groups := resolveEstimateGroups(cfg, opts)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "core", groups[0].ID)
+}
+
+// TestEngineSync_MultiGroupTargetFilterTouchesOneRepo proves SC-1 end-to-end:
+// a multi-group config plus a single target arg runs the single-group path and
+// touches exactly one repository.
+func TestEngineSync_MultiGroupTargetFilterTouchesOneRepo(t *testing.T) {
+	scope := output.CaptureOutput()
+	defer scope.Restore()
+
+	cfg := &config.Config{
+		Version: 1,
+		Groups: []config.Group{
+			{
+				ID:     "core",
+				Name:   "Core",
+				Source: config.SourceConfig{Repo: "org/template", Branch: "master"},
+				Targets: []config.TargetConfig{
+					{Repo: "org/core-a", Files: []config.FileMapping{{Src: "f.txt", Dest: "f.txt"}}},
+				},
+			},
+			{
+				ID:     "libs",
+				Name:   "Libs",
+				Source: config.SourceConfig{Repo: "org/template", Branch: "master"},
+				Targets: []config.TargetConfig{
+					{Repo: "org/lib-a", Files: []config.FileMapping{{Src: "f.txt", Dest: "f.txt"}}},
+				},
+			},
+		},
+	}
+
+	ghClient := &gh.MockClient{}
+	gitClient := &git.MockClient{}
+	gitClient.On("GetChangedFiles", mock.Anything, mock.Anything).Return([]string{"f.txt"}, nil).Maybe()
+	gitClient.On("Diff", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Maybe()
+	gitClient.On("DiffIgnoreWhitespace", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Maybe()
+	stateDiscoverer := &state.MockDiscoverer{}
+	transformChain := &transform.MockChain{}
+
+	ghClient.On("ListBranches", mock.Anything, mock.Anything).Return([]gh.Branch{}, nil).Maybe()
+	ghClient.On("GetRateLimit", mock.Anything).Return(healthyRateLimit(), nil).Maybe()
+	ghClient.On("GetFile", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil, gh.ErrFileNotFound).Maybe()
+	ghClient.On("GetCurrentUser", mock.Anything).Return(&gh.User{Login: "test-user"}, nil).Maybe()
+
+	// State reports the targeted repo as up-to-date so the sync resolves to a
+	// single repo and performs no writes; capturing the discovered config lets
+	// us assert only the narrowed group reached state discovery.
+	var discoveredRepos []string
+	currentState := &state.State{
+		Source: state.SourceState{Repo: "org/template", Branch: "master", LatestCommit: "abc123"},
+		Targets: map[string]*state.TargetState{
+			"org/lib-a": {Repo: "org/lib-a", LastSyncCommit: "abc123", Status: state.StatusUpToDate},
+		},
+	}
+	stateDiscoverer.On("DiscoverState", mock.Anything, mock.Anything).Return(currentState, nil).Run(func(args mock.Arguments) {
+		cfgArg, ok := args.Get(1).(*config.Config)
+		require.True(t, ok)
+		for _, g := range cfgArg.Groups {
+			for _, target := range g.Targets {
+				discoveredRepos = append(discoveredRepos, target.Repo)
+			}
+		}
+	})
+
+	engine := NewEngine(context.Background(), cfg, ghClient, gitClient, stateDiscoverer, transformChain, &Options{MaxConcurrency: 2, RateLimitPreflightEnabled: true, RateLimitPrimaryMarginPercent: 20, RateLimitSecondaryReserve: 10})
+	engine.SetLogger(logrus.New())
+
+	// Target only the repo living in the second group.
+	err := engine.Sync(context.Background(), []string{"org/lib-a"})
+	require.NoError(t, err)
+
+	// Exactly one repo (the targeted one) reached state discovery — the
+	// multi-group blast is gone.
+	assert.Equal(t, []string{"org/lib-a"}, discoveredRepos)
+
+	// The resolved-scope summary is printed before any write (SC-5).
+	assert.Contains(t, scope.Stdout.String(), "1 group(s), 1 repo(s)")
+	assert.Contains(t, scope.Stdout.String(), "org/lib-a")
+}


### PR DESCRIPTION
## Summary
- Implements Harden go-broadcast: honor target/group scope + blast-radius confirmation guard (prevent accidental all-groups sync)

## Validation
- Final validation completed before this PR was opened
