### PR TITLE
go-broadcast: smarter email handling on db target clone (rebase per-repo local-part; add email override flags)

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1375,9 +1375,19 @@ go-broadcast db target update \
   --pr-assignees "contributor" \
   --pr-reviewers "reviewer1,reviewer2" \
   --json
+
+# Set or correct the contact emails directly
+go-broadcast db target update \
+  --group my-tools \
+  --repo owner/go-api \
+  --security-email security@example.com \
+  --support-email support@example.com \
+  --json
 ```
 
-**Updatable fields:** `--branch`, `--pr-labels`, `--pr-assignees`, `--pr-reviewers`
+**Updatable fields:** `--branch`, `--pr-labels`, `--pr-assignees`, `--pr-reviewers`, `--security-email`, `--support-email`
+
+Omitted flags leave the existing value unchanged; passing an empty string clears the field.
 
 </details>
 
@@ -1402,6 +1412,7 @@ go-broadcast db target clone \
   --branch develop \
   --pr-labels "sync,automated" \
   --pr-reviewers "reviewer1" \
+  --security-email security@example.com \
   --json
 ```
 
@@ -1414,7 +1425,20 @@ go-broadcast db target clone \
 - File list references — new join rows pointing to the same shared `file_lists` (not duplicated)
 - Directory list references — new join rows pointing to the same shared `directory_lists` (not duplicated)
 
-**Override flags:** `--branch`, `--pr-labels`, `--pr-assignees`, `--pr-reviewers`, `--pr-team-reviewers` (omitted flags inherit from source)
+**Contact email handling (`security_email` / `support_email`):** Each email column is resolved
+independently when cloning:
+- **Rebased** when the source email follows the per-repo `<repo>@domain` convention — i.e. its
+  local-part exactly (case-sensitive) equals the source repo's short name. The destination repo's
+  short name is substituted as the new local-part and the domain is preserved
+  (e.g. cloning `existing-repo@example.com` to `owner/new-repo` yields `new-repo@example.com`).
+- **Copied verbatim** otherwise — a shared or org-wide email (local-part does not match the source
+  repo short name, e.g. `security@example.org`) is carried over unchanged, never rebased.
+- **Verbatim fallback with a warning** if a rebase would produce an address that fails email
+  validation (an exotic destination repo name). The source value is copied as-is and a warning is
+  printed; the clone still succeeds. Set the address explicitly with `--security-email` /
+  `--support-email` to correct it.
+
+**Override flags:** `--branch`, `--pr-labels`, `--pr-assignees`, `--pr-reviewers`, `--pr-team-reviewers`, `--security-email`, `--support-email` (omitted flags inherit from source; a set `--security-email` / `--support-email` wins over the rebase/verbatim resolution)
 
 **Auto-creates:** The destination repo and organization if they don't exist in the database.
 

--- a/internal/cli/db_crud_json_test.go
+++ b/internal/cli/db_crud_json_test.go
@@ -351,7 +351,7 @@ func TestGroupTargetWrite_JSON(t *testing.T) { //nolint:paralleltest // mutates 
 		cmd.SetContext(context.Background())
 		require.NoError(t, cmd.Flags().Set("branch", "release"))
 		_, err := captureJSON(t, func() error {
-			return runTargetUpdate(cmd, "my-tools", "acme/test-repo-1", "release", "", "", "", true)
+			return runTargetUpdate(cmd, "my-tools", "acme/test-repo-1", "release", "", "", "", "", "", true)
 		})
 		require.NoError(t, err)
 	})
@@ -360,7 +360,7 @@ func TestGroupTargetWrite_JSON(t *testing.T) { //nolint:paralleltest // mutates 
 		cmd := newDBTargetCloneCmd()
 		cmd.SetContext(context.Background())
 		_, err := captureJSON(t, func() error {
-			return runTargetClone(cmd, "my-tools", "acme/test-repo-1", "acme/cloned-repo", "", "", "", "", "", true)
+			return runTargetClone(cmd, "my-tools", "acme/test-repo-1", "acme/cloned-repo", "", "", "", "", "", "", "", true)
 		})
 		require.NoError(t, err)
 	})
@@ -369,7 +369,7 @@ func TestGroupTargetWrite_JSON(t *testing.T) { //nolint:paralleltest // mutates 
 		cmd := newDBTargetCloneCmd()
 		cmd.SetContext(context.Background())
 		err := runTargetClone(cmd, "my-tools", "acme/test-repo-1", "acme/cloned-repo-2",
-			"release", "lbl1,lbl2", "asg1", "rev1", "team1", false)
+			"release", "lbl1,lbl2", "asg1", "rev1", "team1", "", "", false)
 		require.NoError(t, err)
 	})
 
@@ -377,14 +377,14 @@ func TestGroupTargetWrite_JSON(t *testing.T) { //nolint:paralleltest // mutates 
 		cmd := newDBTargetCloneCmd()
 		cmd.SetContext(context.Background())
 		// acme/cloned-repo-2 was just created above.
-		err := runTargetClone(cmd, "my-tools", "acme/test-repo-1", "acme/cloned-repo-2", "", "", "", "", "", false)
+		err := runTargetClone(cmd, "my-tools", "acme/test-repo-1", "acme/cloned-repo-2", "", "", "", "", "", "", "", false)
 		require.Error(t, err)
 	})
 
 	t.Run("target clone missing source errors", func(t *testing.T) {
 		cmd := newDBTargetCloneCmd()
 		cmd.SetContext(context.Background())
-		err := runTargetClone(cmd, "my-tools", "acme/ghost-source", "acme/new-dest", "", "", "", "", "", false)
+		err := runTargetClone(cmd, "my-tools", "acme/ghost-source", "acme/new-dest", "", "", "", "", "", "", "", false)
 		require.Error(t, err)
 	})
 
@@ -392,7 +392,7 @@ func TestGroupTargetWrite_JSON(t *testing.T) { //nolint:paralleltest // mutates 
 		cmd := newDBTargetUpdateCmd()
 		cmd.SetContext(context.Background())
 		require.NoError(t, cmd.Flags().Set("branch", "stable"))
-		require.NoError(t, runTargetUpdate(cmd, "my-tools", "acme/test-repo-1", "stable", "", "", "", false))
+		require.NoError(t, runTargetUpdate(cmd, "my-tools", "acme/test-repo-1", "stable", "", "", "", "", "", false))
 	})
 
 	t.Run("target remove json", func(t *testing.T) {
@@ -423,7 +423,7 @@ func TestGroupTargetWrite_JSON(t *testing.T) { //nolint:paralleltest // mutates 
 		cmdC := newDBTargetCloneCmd()
 		cmdC.SetContext(context.Background())
 		_, err = captureJSON(t, func() error {
-			return runTargetClone(cmdC, "my-tools", "acme/test-repo-1", "acme/dry-clone", "", "", "", "", "", true)
+			return runTargetClone(cmdC, "my-tools", "acme/test-repo-1", "acme/dry-clone", "", "", "", "", "", "", "", true)
 		})
 		require.NoError(t, err)
 
@@ -443,7 +443,7 @@ func TestGroupTargetWrite_JSON(t *testing.T) { //nolint:paralleltest // mutates 
 
 		cmd := newDBTargetCloneCmd()
 		cmd.SetContext(context.Background())
-		require.Error(t, runTargetClone(cmd, "g", "o/a", "o/b", "", "", "", "", "", false))
+		require.Error(t, runTargetClone(cmd, "g", "o/a", "o/b", "", "", "", "", "", "", "", false))
 	})
 }
 

--- a/internal/cli/db_crud_test.go
+++ b/internal/cli/db_crud_test.go
@@ -461,6 +461,117 @@ func TestTargetUpdate(t *testing.T) {
 	})
 }
 
+// TestTargetUpdateEmail verifies the --security-email / --support-email flags on
+// `db target update`: a set flag updates that column, an unset flag leaves the
+// existing value untouched, and a dry-run reports the new value without writing.
+func TestTargetUpdateEmail(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Seed existing contact emails on target1 so we can prove an unset flag leaves
+	// the column untouched while the other column is updated.
+	database, err := openDatabase()
+	require.NoError(t, err)
+	gormDB := database.DB()
+	var seedTarget db.Target
+	require.NoError(t, gormDB.Where("position = ?", 0).First(&seedTarget).Error)
+	seedTarget.SecurityEmail = "old-security@example.com"
+	seedTarget.SupportEmail = "keep-support@example.com"
+	require.NoError(t, gormDB.Save(&seedTarget).Error)
+	require.NoError(t, database.Close())
+
+	// loadTarget fetches the persisted target row for org/name.
+	loadTarget := func(t *testing.T, org, name string) db.Target {
+		t.Helper()
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+		gormDB := database.DB()
+
+		var repo db.Repo
+		require.NoError(t, gormDB.
+			Joins("JOIN organizations ON organizations.id = repos.organization_id").
+			Where("organizations.name = ? AND repos.name = ?", org, name).
+			First(&repo).Error)
+		var target db.Target
+		require.NoError(t, gormDB.Where("repo_id = ?", repo.ID).First(&target).Error)
+		return target
+	}
+
+	t.Run("set security flag, unset support leaves existing value", func(t *testing.T) {
+		cmd := newDBTargetUpdateCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--repo", "acme/test-repo-1",
+			"--security-email", "new-security@example.com",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error { return cmd.Execute() })
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.Equal(t, "updated", resp.Action)
+
+		// Result JSON reports both emails (AC-8).
+		data, ok := resp.Data.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "new-security@example.com", data["security_email"])
+		assert.Equal(t, "keep-support@example.com", data["support_email"])
+
+		// Persisted row: security updated, support left untouched (AC-6).
+		updated := loadTarget(t, "acme", "test-repo-1")
+		assert.Equal(t, "new-security@example.com", updated.SecurityEmail)
+		assert.Equal(t, "keep-support@example.com", updated.SupportEmail)
+	})
+
+	t.Run("set support flag updates support column", func(t *testing.T) {
+		cmd := newDBTargetUpdateCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--repo", "acme/test-repo-1",
+			"--support-email", "new-support@example.com",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error { return cmd.Execute() })
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+
+		// Support column updated; security retains its prior value (AC-6).
+		updated := loadTarget(t, "acme", "test-repo-1")
+		assert.Equal(t, "new-support@example.com", updated.SupportEmail)
+		assert.Equal(t, "new-security@example.com", updated.SecurityEmail)
+	})
+
+	t.Run("dry-run reports new value without writing", func(t *testing.T) {
+		withDryRunEnabled(t)
+
+		before := loadTarget(t, "acme", "test-repo-1")
+
+		cmd := newDBTargetUpdateCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--repo", "acme/test-repo-1",
+			"--security-email", "dryrun@example.com",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error { return cmd.Execute() })
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+
+		// Dry-run reports the new value (AC-8)...
+		data, ok := resp.Data.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "dryrun@example.com", data["security_email"])
+
+		// ...but the persisted row is unchanged.
+		after := loadTarget(t, "acme", "test-repo-1")
+		assert.Equal(t, before.SecurityEmail, after.SecurityEmail)
+	})
+}
+
 func TestTargetGet(t *testing.T) {
 	cleanup := setupTestDB(t)
 	defer cleanup()
@@ -1356,6 +1467,154 @@ func TestTargetClone(t *testing.T) {
 		var org db.Organization
 		require.NoError(t, gormDB.Where("name = ?", "neworg").First(&org).Error)
 		assert.Equal(t, "neworg", org.Name)
+	})
+}
+
+// TestTargetCloneEmail verifies contact-email handling on clone: per-repo addresses
+// are rebased to the destination repo short name, shared/org addresses are copied
+// verbatim, an explicit flag overrides the resolved value (independently per column),
+// and a dry-run reports the resolved emails without writing a row.
+func TestTargetCloneEmail(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Seed source contact emails: target1 (test-repo-1) follows the per-repo
+	// convention (local-part == repo short name) so a clone should rebase it;
+	// target2 (test-repo-2) uses a shared/org address that must be copied verbatim.
+	database, err := openDatabase()
+	require.NoError(t, err)
+	gormDB := database.DB()
+
+	var target1 db.Target
+	require.NoError(t, gormDB.Where("position = ?", 0).First(&target1).Error)
+	target1.SecurityEmail = "test-repo-1@example.com"
+	target1.SupportEmail = "test-repo-1@example.com"
+	require.NoError(t, gormDB.Save(&target1).Error)
+
+	var target2 db.Target
+	require.NoError(t, gormDB.Where("position = ?", 1).First(&target2).Error)
+	target2.SecurityEmail = "security@example.org"
+	target2.SupportEmail = "security@example.org"
+	require.NoError(t, gormDB.Save(&target2).Error)
+
+	require.NoError(t, database.Close())
+
+	// loadClonedTarget fetches the persisted cloned target row for org/name.
+	loadClonedTarget := func(t *testing.T, org, name string) db.Target {
+		t.Helper()
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+		gormDB := database.DB()
+
+		var repo db.Repo
+		require.NoError(t, gormDB.
+			Joins("JOIN organizations ON organizations.id = repos.organization_id").
+			Where("organizations.name = ? AND repos.name = ?", org, name).
+			First(&repo).Error)
+		var target db.Target
+		require.NoError(t, gormDB.Where("repo_id = ?", repo.ID).First(&target).Error)
+		return target
+	}
+
+	t.Run("rebase per-repo email to destination short name", func(t *testing.T) {
+		cmd := newDBTargetCloneCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--from", "acme/test-repo-1",
+			"--to", "acme/go-actions",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error { return cmd.Execute() })
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+
+		// Result JSON reports the rebased emails (AC-8, real path).
+		data, ok := resp.Data.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "go-actions@example.com", data["security_email"])
+		assert.Equal(t, "go-actions@example.com", data["support_email"])
+
+		// Persisted row carries the rebased emails for both columns (AC-1, AC-4).
+		cloned := loadClonedTarget(t, "acme", "go-actions")
+		assert.Equal(t, "go-actions@example.com", cloned.SecurityEmail)
+		assert.Equal(t, "go-actions@example.com", cloned.SupportEmail)
+	})
+
+	t.Run("shared org email copied verbatim", func(t *testing.T) {
+		cmd := newDBTargetCloneCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--from", "acme/test-repo-2",
+			"--to", "acme/go-cache",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error { return cmd.Execute() })
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+
+		// Shared/org address is unchanged on both columns (AC-2).
+		cloned := loadClonedTarget(t, "acme", "go-cache")
+		assert.Equal(t, "security@example.org", cloned.SecurityEmail)
+		assert.Equal(t, "security@example.org", cloned.SupportEmail)
+	})
+
+	t.Run("explicit flag overrides rebase per column", func(t *testing.T) {
+		cmd := newDBTargetCloneCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--from", "acme/test-repo-1",
+			"--to", "acme/go-fortress",
+			"--security-email", "custom@override.com",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error { return cmd.Execute() })
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+
+		// The explicit flag wins for security; support (no flag) still rebases —
+		// proving the override applies independently per column (AC-5, AC-4).
+		cloned := loadClonedTarget(t, "acme", "go-fortress")
+		assert.Equal(t, "custom@override.com", cloned.SecurityEmail)
+		assert.Equal(t, "go-fortress@example.com", cloned.SupportEmail)
+	})
+
+	t.Run("dry-run reports resolved emails without writing", func(t *testing.T) {
+		withDryRunEnabled(t)
+
+		database, err := openDatabase()
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		var before int64
+		require.NoError(t, database.DB().Model(&db.Target{}).Count(&before).Error)
+
+		cmd := newDBTargetCloneCmd()
+		cmd.SetArgs([]string{
+			"--group", "my-tools",
+			"--from", "acme/test-repo-1",
+			"--to", "acme/dry-dest",
+			"--json",
+		})
+
+		resp, err := captureJSON(t, func() error { return cmd.Execute() })
+		require.NoError(t, err)
+		assert.True(t, resp.Success)
+		assert.True(t, resp.DryRun)
+
+		// Dry-run reports the resolved emails for both columns (AC-8)...
+		data, ok := resp.Data.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "dry-dest@example.com", data["security_email"])
+		assert.Equal(t, "dry-dest@example.com", data["support_email"])
+
+		// ...but writes no row.
+		var after int64
+		require.NoError(t, database.DB().Model(&db.Target{}).Count(&after).Error)
+		assert.Equal(t, before, after)
 	})
 }
 

--- a/internal/cli/db_target_crud.go
+++ b/internal/cli/db_target_crud.go
@@ -17,10 +17,12 @@ import (
 
 // targetListResult is the JSON-serializable result for target list
 type targetListResult struct {
-	Repo     string `json:"repo"`
-	Branch   string `json:"branch,omitempty"`
-	Position int    `json:"position"`
-	GroupID  string `json:"group_id"`
+	Repo          string `json:"repo"`
+	Branch        string `json:"branch,omitempty"`
+	Position      int    `json:"position"`
+	GroupID       string `json:"group_id"`
+	SecurityEmail string `json:"security_email,omitempty"`
+	SupportEmail  string `json:"support_email,omitempty"`
 }
 
 // targetDetailResult is the JSON-serializable result for target get
@@ -448,19 +450,21 @@ func runTargetRemove(groupExternalID, repoFullName string, hard, jsonOutput bool
 
 func newDBTargetUpdateCmd() *cobra.Command {
 	var (
-		jsonOutput  bool
-		groupID     string
-		repo        string
-		branch      string
-		prLabels    string
-		prAssignees string
-		prReviewers string
+		jsonOutput    bool
+		groupID       string
+		repo          string
+		branch        string
+		prLabels      string
+		prAssignees   string
+		prReviewers   string
+		securityEmail string
+		supportEmail  string
 	)
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update target settings",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTargetUpdate(cmd, groupID, repo, branch, prLabels, prAssignees, prReviewers, jsonOutput)
+			return runTargetUpdate(cmd, groupID, repo, branch, prLabels, prAssignees, prReviewers, securityEmail, supportEmail, jsonOutput)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
@@ -470,12 +474,14 @@ func newDBTargetUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&prLabels, "pr-labels", "", "Comma-separated PR labels")
 	cmd.Flags().StringVar(&prAssignees, "pr-assignees", "", "Comma-separated PR assignees")
 	cmd.Flags().StringVar(&prReviewers, "pr-reviewers", "", "Comma-separated PR reviewers")
+	cmd.Flags().StringVar(&securityEmail, "security-email", "", "Set the security contact email (omit to leave unchanged)")
+	cmd.Flags().StringVar(&supportEmail, "support-email", "", "Set the support contact email (omit to leave unchanged)")
 	_ = cmd.MarkFlagRequired("group")
 	_ = cmd.MarkFlagRequired("repo")
 	return cmd
 }
 
-func runTargetUpdate(cmd *cobra.Command, groupExternalID, repoFullName, branch, prLabels, prAssignees, prReviewers string, jsonOutput bool) error {
+func runTargetUpdate(cmd *cobra.Command, groupExternalID, repoFullName, branch, prLabels, prAssignees, prReviewers, securityEmail, supportEmail string, jsonOutput bool) error {
 	database, err := openDatabase()
 	if err != nil {
 		return printErrorResponse("target", "updated", err.Error(), "", jsonOutput)
@@ -509,12 +515,23 @@ func runTargetUpdate(cmd *cobra.Command, groupExternalID, repoFullName, branch, 
 	if cmd.Flags().Changed("pr-reviewers") {
 		target.PRReviewers = splitCSV(prReviewers)
 	}
+	// An unset email flag means no change; setting it to empty clears the column
+	// (mirrors the string-field set convention). The DB-layer BeforeUpdate hook
+	// validates the address, so no extra validation is needed here.
+	if cmd.Flags().Changed("security-email") {
+		target.SecurityEmail = securityEmail
+	}
+	if cmd.Flags().Changed("support-email") {
+		target.SupportEmail = supportEmail
+	}
 
 	result := targetListResult{
-		Repo:     repoFullName,
-		Branch:   target.Branch,
-		Position: target.Position,
-		GroupID:  groupExternalID,
+		Repo:          repoFullName,
+		Branch:        target.Branch,
+		Position:      target.Position,
+		GroupID:       groupExternalID,
+		SecurityEmail: target.SecurityEmail,
+		SupportEmail:  target.SupportEmail,
 	}
 
 	if IsDryRun() {
@@ -547,6 +564,22 @@ func resolveRepoName(ctx context.Context, gormDB *gorm.DB, repoID uint) string {
 	return fmt.Sprintf("repo-id-%d", repoID)
 }
 
+// resolveTargetEmail resolves a single contact email column for a clone destination.
+// An explicitly provided flag value always wins; otherwise the source email is
+// rebased to the destination repo short name (per-repo convention), copied verbatim
+// (shared/org email), or copied verbatim with a warning when a rebase would be
+// invalid. Any warning is surfaced once, here, so the resolver stays pure.
+func resolveTargetEmail(cmd *cobra.Command, flagName, flagValue, sourceEmail, srcShort, dstShort string) string {
+	if cmd.Flags().Changed(flagName) {
+		return flagValue
+	}
+	resolved, warning := resolveClonedEmail(sourceEmail, srcShort, dstShort)
+	if warning != "" {
+		output.Warn(warning)
+	}
+	return resolved
+}
+
 // splitCSV splits a comma-separated string into a JSONStringSlice, trimming whitespace
 func splitCSV(s string) db.JSONStringSlice {
 	if s == "" {
@@ -574,6 +607,8 @@ func newDBTargetCloneCmd() *cobra.Command {
 		prAssignees     string
 		prReviewers     string
 		prTeamReviewers string
+		securityEmail   string
+		supportEmail    string
 		createRepo      bool
 		presetID        string
 		topicsStr       string
@@ -587,7 +622,7 @@ func newDBTargetCloneCmd() *cobra.Command {
 
 With --create-repo, also creates the GitHub repository using the scaffold flow before cloning the target.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTargetClone(cmd, groupID, from, to, branch, prLabels, prAssignees, prReviewers, prTeamReviewers, jsonOutput)
+			return runTargetClone(cmd, groupID, from, to, branch, prLabels, prAssignees, prReviewers, prTeamReviewers, securityEmail, supportEmail, jsonOutput)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
@@ -599,6 +634,8 @@ With --create-repo, also creates the GitHub repository using the scaffold flow b
 	cmd.Flags().StringVar(&prAssignees, "pr-assignees", "", "Override comma-separated PR assignees")
 	cmd.Flags().StringVar(&prReviewers, "pr-reviewers", "", "Override comma-separated PR reviewers")
 	cmd.Flags().StringVar(&prTeamReviewers, "pr-team-reviewers", "", "Override comma-separated PR team reviewers")
+	cmd.Flags().StringVar(&securityEmail, "security-email", "", "Override the security contact email for the new target")
+	cmd.Flags().StringVar(&supportEmail, "support-email", "", "Override the support contact email for the new target")
 	cmd.Flags().BoolVar(&createRepo, "create-repo", false, "Create the GitHub repository before cloning target")
 	cmd.Flags().StringVar(&presetID, "preset", "mvp", "Settings preset ID (used with --create-repo)")
 	cmd.Flags().StringVar(&topicsStr, "topics", "", "Comma-separated topics (used with --create-repo)")
@@ -616,7 +653,7 @@ With --create-repo, also creates the GitHub repository using the scaffold flow b
 	return cmd
 }
 
-func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branch, prLabels, prAssignees, prReviewers, prTeamReviewers string, jsonOutput bool) error {
+func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branch, prLabels, prAssignees, prReviewers, prTeamReviewers, securityEmail, supportEmail string, jsonOutput bool) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -726,15 +763,26 @@ func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branc
 		previewBranch = branch
 	}
 
+	// Resolve the contact emails for the destination. A per-repo address (local-part
+	// equal to the source repo's short name) is rebased to the destination repo's
+	// short name; a shared/org address is copied verbatim; an invalid rebase falls
+	// back to a verbatim copy with a warning. An explicit flag always wins.
+	srcShort := repoShortName(resolveRepoName(ctx, gormDB, source.RepoID))
+	dstShort := repoShortName(toRepo)
+	resolvedSecurityEmail := resolveTargetEmail(cmd, "security-email", securityEmail, source.SecurityEmail, srcShort, dstShort)
+	resolvedSupportEmail := resolveTargetEmail(cmd, "support-email", supportEmail, source.SupportEmail, srcShort, dstShort)
+
 	if IsDryRun() {
 		return printDryRunResponse(CLIResponse{
 			Action: "cloned",
 			Type:   "target",
 			Data: targetListResult{
-				Repo:     toRepo,
-				Branch:   previewBranch,
-				Position: len(targets),
-				GroupID:  groupExternalID,
+				Repo:          toRepo,
+				Branch:        previewBranch,
+				Position:      len(targets),
+				GroupID:       groupExternalID,
+				SecurityEmail: resolvedSecurityEmail,
+				SupportEmail:  resolvedSupportEmail,
 			},
 			Hint: fmt.Sprintf("cloned from %s", fromRepo),
 		}, fmt.Sprintf("clone target %q to %q in group %q", fromRepo, toRepo, groupExternalID), jsonOutput)
@@ -744,7 +792,8 @@ func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branc
 	var newTarget *db.Target
 	err = gormDB.Transaction(func(tx *gorm.DB) error {
 		newTarget, err = cloneTargetInTx(ctx, cmd, tx, source, group.ID, toRepo, len(targets),
-			branch, prLabels, prAssignees, prReviewers, prTeamReviewers)
+			branch, prLabels, prAssignees, prReviewers, prTeamReviewers,
+			resolvedSecurityEmail, resolvedSupportEmail)
 		return err
 	})
 	if err != nil {
@@ -752,10 +801,12 @@ func runTargetClone(cmd *cobra.Command, groupExternalID, fromRepo, toRepo, branc
 	}
 
 	result := targetListResult{
-		Repo:     toRepo,
-		Branch:   newTarget.Branch,
-		Position: newTarget.Position,
-		GroupID:  groupExternalID,
+		Repo:          toRepo,
+		Branch:        newTarget.Branch,
+		Position:      newTarget.Position,
+		GroupID:       groupExternalID,
+		SecurityEmail: newTarget.SecurityEmail,
+		SupportEmail:  newTarget.SupportEmail,
 	}
 
 	return printResponse(CLIResponse{
@@ -776,6 +827,7 @@ func cloneTargetInTx(
 	toRepo string,
 	position int,
 	branch, prLabels, prAssignees, prReviewers, prTeamReviewers string,
+	securityEmail, supportEmail string,
 ) (*db.Target, error) {
 	// Resolve destination repo (auto-creates client/org/repo)
 	repoRepo := db.NewRepoRepository(tx)
@@ -784,14 +836,15 @@ func cloneTargetInTx(
 		return nil, fmt.Errorf("failed to resolve destination repo: %w", err)
 	}
 
-	// Create new Target record - copy scalar fields from source
+	// Create new Target record - copy scalar fields from source. The contact emails
+	// are pre-resolved by the caller (rebase / verbatim / explicit override).
 	newTarget := &db.Target{
 		GroupID:         groupID,
 		RepoID:          destRepo.ID,
 		Branch:          source.Branch,
 		BlobSizeLimit:   source.BlobSizeLimit,
-		SecurityEmail:   source.SecurityEmail,
-		SupportEmail:    source.SupportEmail,
+		SecurityEmail:   securityEmail,
+		SupportEmail:    supportEmail,
 		PRLabels:        copyJSONStringSlice(source.PRLabels),
 		PRAssignees:     copyJSONStringSlice(source.PRAssignees),
 		PRReviewers:     copyJSONStringSlice(source.PRReviewers),

--- a/internal/cli/db_target_email.go
+++ b/internal/cli/db_target_email.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mrz1836/go-broadcast/internal/validation"
+)
+
+// repoShortName returns the repository short name: the segment after the final
+// "/" of an "org/repo" full name (e.g. "org/service-a" -> "service-a").
+// A name without a "/" is returned unchanged ("service-a" -> "service-a"),
+// and only the last segment is taken ("a/b/c" -> "c").
+func repoShortName(fullName string) string {
+	if idx := strings.LastIndex(fullName, "/"); idx >= 0 {
+		return fullName[idx+1:]
+	}
+	return fullName
+}
+
+// resolveClonedEmail decides how a single contact email column is carried from a
+// source target to a cloned destination target. It is pure (no DB, no cobra) so
+// the rebase/verbatim/fallback matrix is fast and deterministic to test.
+//
+// The rule:
+//   - An empty source email is copied empty (no rebase).
+//   - If the source local-part exactly (case-sensitive, byte-for-byte) equals the
+//     source repo's short name, the address follows the per-repo "<repo>@domain"
+//     convention: the destination repo's short name is substituted as the new
+//     local-part, preserving the domain (e.g. "service-a@example.com" cloned to
+//     "service-b" -> "service-b@example.com").
+//   - Otherwise the address is a shared/org email (e.g. "security@example.org")
+//     and is copied verbatim — no rebasing.
+//   - If a rebase would produce an address that fails email validation (an exotic
+//     destination repo name), the source email is copied verbatim and a warning is
+//     returned; the clone never hard-fails and never writes a malformed address.
+//
+// It returns the resolved email and an optional colleague-safe warning (empty when
+// there is nothing to warn about).
+func resolveClonedEmail(sourceEmail, srcShortName, dstShortName string) (resolved, warning string) {
+	// Empty source email: copy empty, never rebase.
+	if sourceEmail == "" {
+		return "", ""
+	}
+
+	// Split on the last "@"; if there is none, leave pre-existing odd data untouched.
+	at := strings.LastIndex(sourceEmail, "@")
+	if at < 0 {
+		return sourceEmail, "" // verbatim: not an address we understand
+	}
+
+	localPart := sourceEmail[:at]
+	domain := sourceEmail[at+1:]
+
+	// Shared/org email (local-part does not match the source repo short name):
+	// copy verbatim so org-wide and intentionally shared contacts are preserved.
+	if localPart != srcShortName {
+		return sourceEmail, "" // verbatim: shared/org email, no rebase
+	}
+
+	// Per-repo convention matched: rebase the local-part to the destination short name.
+	candidate := dstShortName + "@" + domain
+	if validation.ValidateEmail(candidate, "security_email/support_email") != nil {
+		// Invalid rebase (exotic destination repo name): copy source verbatim + warn.
+		warning = fmt.Sprintf(
+			"could not rebase contact email to %q (invalid address); copied source value %q verbatim — set it explicitly with --security-email/--support-email",
+			candidate, sourceEmail,
+		)
+		return sourceEmail, warning
+	}
+
+	return candidate, ""
+}

--- a/internal/cli/db_target_email_test.go
+++ b/internal/cli/db_target_email_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveClonedEmail exercises the full rebase/verbatim/fallback matrix for a
+// single cloned contact email column. Each case is labeled with the column it
+// represents (security_email or support_email) so both columns share — and are
+// proven to follow — the same resolver behavior.
+func TestResolveClonedEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		column       string // security_email or support_email — both columns use this resolver
+		sourceEmail  string
+		srcShortName string
+		dstShortName string
+		wantResolved string
+		wantWarning  bool
+	}{
+		{
+			name:         "per-repo rebase security_email",
+			column:       "security_email",
+			sourceEmail:  "service-a@example.com",
+			srcShortName: "service-a",
+			dstShortName: "service-b",
+			wantResolved: "service-b@example.com",
+			wantWarning:  false,
+		},
+		{
+			name:         "per-repo rebase support_email",
+			column:       "support_email",
+			sourceEmail:  "service-a@example.com",
+			srcShortName: "service-a",
+			dstShortName: "service-c",
+			wantResolved: "service-c@example.com",
+			wantWarning:  false,
+		},
+		{
+			name:         "shared org email copied verbatim security_email",
+			column:       "security_email",
+			sourceEmail:  "security@example.org",
+			srcShortName: "service-a",
+			dstShortName: "service-b",
+			wantResolved: "security@example.org",
+			wantWarning:  false,
+		},
+		{
+			name:         "shared project email copied verbatim support_email",
+			column:       "support_email",
+			sourceEmail:  "contact@example.net",
+			srcShortName: "service-a",
+			dstShortName: "service-b",
+			wantResolved: "contact@example.net",
+			wantWarning:  false,
+		},
+		{
+			name:         "cross-name email copied verbatim security_email",
+			column:       "security_email",
+			sourceEmail:  "team@example.com",
+			srcShortName: "service-a",
+			dstShortName: "service-b",
+			wantResolved: "team@example.com",
+			wantWarning:  false,
+		},
+		{
+			name:         "empty source copied empty support_email",
+			column:       "support_email",
+			sourceEmail:  "",
+			srcShortName: "service-a",
+			dstShortName: "service-b",
+			wantResolved: "",
+			wantWarning:  false,
+		},
+		{
+			name:         "rebase no-op when source and dest short names match security_email",
+			column:       "security_email",
+			sourceEmail:  "service-a@example.com",
+			srcShortName: "service-a",
+			dstShortName: "service-a",
+			wantResolved: "service-a@example.com",
+			wantWarning:  false,
+		},
+		{
+			name:         "invalid rebase falls back to verbatim and warns support_email",
+			column:       "support_email",
+			sourceEmail:  "service-a@example.com",
+			srcShortName: "service-a",
+			dstShortName: ".github", // leading dot -> invalid local-part
+			wantResolved: "service-a@example.com",
+			wantWarning:  true,
+		},
+		{
+			name:         "source without @ copied verbatim security_email",
+			column:       "security_email",
+			sourceEmail:  "not-an-email",
+			srcShortName: "service-a",
+			dstShortName: "service-b",
+			wantResolved: "not-an-email",
+			wantWarning:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotResolved, gotWarning := resolveClonedEmail(tt.sourceEmail, tt.srcShortName, tt.dstShortName)
+
+			assert.Equalf(t, tt.wantResolved, gotResolved, "resolved %s mismatch", tt.column)
+			if tt.wantWarning {
+				assert.NotEmptyf(t, gotWarning, "expected a warning for %s", tt.column)
+			} else {
+				assert.Emptyf(t, gotWarning, "expected no warning for %s", tt.column)
+			}
+		})
+	}
+}
+
+// TestRepoShortName verifies that the short name is the segment after the final "/".
+func TestRepoShortName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fullName string
+		want     string
+	}{
+		{name: "org/repo", fullName: "org/service-a", want: "service-a"},
+		{name: "bare repo", fullName: "service-a", want: "service-a"},
+		{name: "three segments", fullName: "a/b/c", want: "c"},
+		{name: "empty", fullName: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, repoShortName(tt.fullName))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements go-broadcast: smarter email handling on db target clone (rebase per-repo local-part; add email override flags)

## Validation
- Final validation completed before this PR was opened
